### PR TITLE
Sivalue string refactor

### DIFF
--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -528,7 +528,7 @@ SIValue AR_TOSTRING(SIValue *argv, int argc) {
 
     if(SIValue_IsNull(argv[0])) return SI_NullVal();
     size_t len = 128;
-    char str[len];
+    char str[128] = {0};
     SIValue_ToString(argv[0], str, len);
     return SI_StringVal(str);
 }

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -1,7 +1,7 @@
-#include "arithmetic_expression.h"
-#include "./util/triemap/triemap.h"
-#include "./arithmetic/aggregate.h"
-#include "./arithmetic/repository.h"
+#include "./arithmetic_expression.h"
+#include "../util/triemap/triemap.h"
+#include "./aggregate.h"
+#include "./repository.h"
 
 #include "assert.h"
 #include <math.h>

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -426,7 +426,7 @@ SIValue AR_REVERSE(SIValue *argv, int argc) {
     if(SIValue_IsNull(argv[0])) return SI_NullVal();
     assert(argv[0].type == T_STRING);
     char *str = argv[0].stringval;
-    size_t str_len = strlen(argv[0].stringval);
+    size_t str_len = strlen(str);
     char reverse[str_len + 1];
     
     int i = str_len-1;
@@ -449,7 +449,7 @@ SIValue AR_SUBSTRING(SIValue *argv, int argc) {
     assert(argc > 1);
     if(SIValue_IsNull(argv[0])) return SI_NullVal();
     char *original = argv[0].stringval;
-    size_t original_len = strlen(argv[0].stringval);
+    size_t original_len = strlen(original);
     int start = (int)argv[1].doubleval;
     size_t length;
 
@@ -493,7 +493,7 @@ SIValue AR_TOLOWER(SIValue *argv, int argc) {
 
     if(SIValue_IsNull(argv[0])) return SI_NullVal();
     char *original = argv[0].stringval;
-    size_t lower_len = strlen(argv[0].stringval) + 1;
+    size_t lower_len = strlen(original) + 1;
     char lower[lower_len];
     _toLower(original, lower, &lower_len);
     return SI_StringVal(lower);
@@ -517,7 +517,7 @@ SIValue AR_TOUPPER(SIValue *argv, int argc) {
 
     if(SIValue_IsNull(argv[0])) return SI_NullVal();
     char *original = argv[0].stringval;
-    size_t upper_len = strlen(argv[0].stringval) + 1;
+    size_t upper_len = strlen(original) + 1;
     char upper[upper_len];
     _toUpper(original, upper, &upper_len);
     return SI_StringVal(upper);

--- a/src/bulk_insert.c
+++ b/src/bulk_insert.c
@@ -106,8 +106,8 @@ RedisModuleString** _Bulk_Insert_Read_Labeled_Node_Attributes(RedisModuleCtx *ct
 
     for(int i = 0; i < attribute_count; i++) {
         size_t attribute_len;
-        char *attribute_val = strdup((char*)RedisModule_StringPtrLen(*argv++, &attribute_len));
-        SIValue_FromString(&values[i], attribute_val);
+        char *attribute_val = (char*)RedisModule_StringPtrLen(*argv++, &attribute_len);
+        values[i] = SIValue_FromString(attribute_val);
     }
 
     return argv;
@@ -131,7 +131,7 @@ RedisModuleString** _Bulk_Insert_Read_Unlabeled_Node_Attributes(RedisModuleCtx *
 
         size_t attribute_len;
         char *attribute_val = (char*)RedisModule_StringPtrLen(*argv++, &attribute_len);
-        SIValue_FromString(&values[i], attribute_val);
+        values[i] = SIValue_FromString(attribute_val);
     }
 
     return argv;

--- a/src/bulk_insert.c
+++ b/src/bulk_insert.c
@@ -107,7 +107,7 @@ RedisModuleString** _Bulk_Insert_Read_Labeled_Node_Attributes(RedisModuleCtx *ct
     for(int i = 0; i < attribute_count; i++) {
         size_t attribute_len;
         char *attribute_val = strdup((char*)RedisModule_StringPtrLen(*argv++, &attribute_len));
-        SIValue_FromString(&values[i], attribute_val, attribute_len);
+        SIValue_FromString(&values[i], attribute_val);
     }
 
     return argv;
@@ -131,7 +131,7 @@ RedisModuleString** _Bulk_Insert_Read_Unlabeled_Node_Attributes(RedisModuleCtx *
 
         size_t attribute_len;
         char *attribute_val = (char*)RedisModule_StringPtrLen(*argv++, &attribute_len);
-        SIValue_FromString(&values[i], attribute_val, attribute_len);
+        SIValue_FromString(&values[i], attribute_val);
     }
 
     return argv;

--- a/src/execution_plan/ops/op_aggregate.c
+++ b/src/execution_plan/ops/op_aggregate.c
@@ -57,11 +57,7 @@ char* _computeGroupKey(Aggregate *op, SIValue *group_keys) {
         group_keys[i] = AR_EXP_Evaluate(exp);
     }
 
-    // Determin required size for group string representation.
-    size_t str_group_len = SIValue_StringConcatLen(group_keys,op->none_aggregated_expression_count);
-    str_group = malloc(sizeof(char) * str_group_len);
-
-    SIValue_StringConcat(group_keys, op->none_aggregated_expression_count, str_group, str_group_len);
+    SIValue_StringConcat(group_keys, op->none_aggregated_expression_count, &str_group);
     return str_group;
 }
 

--- a/src/execution_plan/ops/op_aggregate.c
+++ b/src/execution_plan/ops/op_aggregate.c
@@ -57,7 +57,11 @@ char* _computeGroupKey(Aggregate *op, SIValue *group_keys) {
         group_keys[i] = AR_EXP_Evaluate(exp);
     }
 
-    SIValue_StringConcat(group_keys, op->none_aggregated_expression_count, &str_group);
+    // Determine required size for group string representation.
+    size_t str_group_len = SIValue_StringConcatLen(group_keys,op->none_aggregated_expression_count);
+    str_group = malloc(sizeof(char) * str_group_len);
+
+    SIValue_StringConcat(group_keys, op->none_aggregated_expression_count, str_group, str_group_len);
     return str_group;
 }
 

--- a/src/graph/graph_type.c
+++ b/src/graph/graph_type.c
@@ -126,14 +126,14 @@ void _GraphType_SaveNode(RedisModuleIO *rdb, const Node *n) {
 
     for(int i = 0; i < n->prop_count; i++) {
         EntityProperty prop = n->properties[i];
-        RedisModule_SaveStringBuffer(rdb, prop.name, strlen(prop.name));        
+        RedisModule_SaveStringBuffer(rdb, prop.name, strlen(prop.name) + 1);
         
         RedisModule_SaveUnsigned(rdb, prop.value.type);
         
         if(prop.value.type & SI_NUMERIC) {
             RedisModule_SaveDouble(rdb, prop.value.doubleval);
         } else {
-            RedisModule_SaveStringBuffer(rdb, prop.value.stringval, strlen(prop.value.stringval));
+            RedisModule_SaveStringBuffer(rdb, prop.value.stringval, strlen(prop.value.stringval) + 1);
         }        
     }
 }

--- a/src/graph/graph_type.c
+++ b/src/graph/graph_type.c
@@ -77,7 +77,7 @@ void _GraphType_LoadNodes(RedisModuleIO *rdb, Graph *g) {
             if(t & SI_NUMERIC) {
                 propValue[i] = SI_DoubleVal(RedisModule_LoadDouble(rdb));
             } else {
-                propValue[i] = SI_StringValC(RedisModule_LoadStringBuffer(rdb, NULL));
+                propValue[i] = SI_StringVal(RedisModule_LoadStringBuffer(rdb, NULL));
             }
         }
 
@@ -133,7 +133,7 @@ void _GraphType_SaveNode(RedisModuleIO *rdb, const Node *n) {
         if(prop.value.type & SI_NUMERIC) {
             RedisModule_SaveDouble(rdb, prop.value.doubleval);
         } else {
-            RedisModule_SaveStringBuffer(rdb, prop.value.stringval.str, prop.value.stringval.len);
+            RedisModule_SaveStringBuffer(rdb, prop.value.stringval, strlen(prop.value.stringval));
         }        
     }
 }

--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -94,7 +94,7 @@ void _BuildQueryGraphAddProps(AST_GraphEntity *entity, GraphEntity* e) {
             Vector_Get(entity->properties, prop_idx+1, &value);
 
             values[prop_idx/2] = *value;
-            keys[prop_idx/2] = key->stringval.str;
+            keys[prop_idx/2] = key->stringval;
         }
 
         GraphEntity_Add_Properties(e, prop_count/2, keys, values);

--- a/src/parser/grammar.c
+++ b/src/parser/grammar.c
@@ -1416,7 +1416,7 @@ static void yy_reduce(
 	yylhsminor.yy114 = NewVector(SIValue*, 2);
 
 	SIValue *key = malloc(sizeof(SIValue));
-	*key = SI_StringValC(strdup(yymsp[-2].minor.yy0.strval));
+	*key = SI_StringVal(yymsp[-2].minor.yy0.strval);
 	Vector_Push(yylhsminor.yy114, key);
 
 	SIValue *val = malloc(sizeof(SIValue));
@@ -1430,7 +1430,7 @@ static void yy_reduce(
 #line 227 "grammar.y"
 {
 	SIValue *key = malloc(sizeof(SIValue));
-	*key = SI_StringValC(strdup(yymsp[-4].minor.yy0.strval));
+	*key = SI_StringVal(yymsp[-4].minor.yy0.strval);
 	Vector_Push(yymsp[0].minor.yy114, key);
 
 	SIValue *val = malloc(sizeof(SIValue));
@@ -1759,7 +1759,7 @@ static void yy_reduce(
         break;
       case 77: /* value ::= STRING */
 #line 439 "grammar.y"
-{  yylhsminor.yy86 = SI_StringValC(strdup(yymsp[0].minor.yy0.strval)); }
+{  yylhsminor.yy86 = SI_StringVal(yymsp[0].minor.yy0.strval); }
 #line 1764 "grammar.c"
   yymsp[0].minor.yy86 = yylhsminor.yy86;
         break;

--- a/src/parser/grammar.y
+++ b/src/parser/grammar.y
@@ -216,7 +216,7 @@ mapLiteral(A) ::= UQSTRING(B) COLON value(C). {
 	A = NewVector(SIValue*, 2);
 
 	SIValue *key = malloc(sizeof(SIValue));
-	*key = SI_StringValC(strdup(B.strval));
+	*key = SI_StringVal(B.strval);
 	Vector_Push(A, key);
 
 	SIValue *val = malloc(sizeof(SIValue));
@@ -226,7 +226,7 @@ mapLiteral(A) ::= UQSTRING(B) COLON value(C). {
 
 mapLiteral(A) ::= UQSTRING(B) COLON value(C) COMMA mapLiteral(D). {
 	SIValue *key = malloc(sizeof(SIValue));
-	*key = SI_StringValC(strdup(B.strval));
+	*key = SI_StringVal(B.strval);
 	Vector_Push(D, key);
 
 	SIValue *val = malloc(sizeof(SIValue));
@@ -436,7 +436,7 @@ relation(A) ::= NE. { A = NE; }
 // raw value tokens - int / string / float
 value(A) ::= INTEGER(B). {  A = SI_DoubleVal(B.intval); }
 value(A) ::= DASH INTEGER(B). {  A = SI_DoubleVal(-B.intval); }
-value(A) ::= STRING(B). {  A = SI_StringValC(strdup(B.strval)); }
+value(A) ::= STRING(B). {  A = SI_StringVal(B.strval); }
 value(A) ::= FLOAT(B). {  A = SI_DoubleVal(B.dval); }
 value(A) ::= DASH FLOAT(B). {  A = SI_DoubleVal(-B.dval); }
 value(A) ::= TRUE. { A = SI_BoolVal(1); }

--- a/src/parser/lex.yy.c
+++ b/src/parser/lex.yy.c
@@ -7,8 +7,8 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -46,7 +46,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -54,7 +53,6 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -85,63 +83,61 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
+#endif /* ! C99 */
+
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -158,15 +154,16 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
+    #define YY_LINENO_REWIND_TO(ptr)
     
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
@@ -181,7 +178,6 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -196,12 +192,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -224,7 +220,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -252,7 +248,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -263,7 +259,6 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -271,11 +266,11 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
@@ -284,82 +279,78 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void yyensure_buffer_stack (void );
-static void yy_load_buffer_state (void );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
-
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *yyin = (FILE *) 0, *yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
 extern int yylineno;
-
 int yylineno = 1;
 
 extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (yy_size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 45
 #define YY_END_OF_BUFFER 46
 /* This struct is not used in this scanner,
@@ -369,7 +360,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[116] =
+static const flex_int16_t yy_accept[116] =
     {   0,
         0,    0,   46,   45,   43,   44,   45,   45,   45,   23,
        24,   41,   42,   22,   37,   39,   40,   19,   38,   36,
@@ -386,7 +377,7 @@ static yyconst flex_int16_t yy_accept[116] =
        20,    8,   20,   11,    0
     } ;
 
-static yyconst flex_int32_t yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -418,7 +409,7 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int32_t yy_meta[62] =
+static const YY_CHAR yy_meta[62] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    2,    1,    1,    2,    1,    1,    1,    1,    2,
@@ -429,7 +420,7 @@ static yyconst flex_int32_t yy_meta[62] =
         1
     } ;
 
-static yyconst flex_int16_t yy_base[121] =
+static const flex_int16_t yy_base[121] =
     {   0,
         0,    0,  204,  229,  201,  229,  184,   57,   58,  229,
       229,  229,  229,  229,  182,  182,  229,   50,  229,   54,
@@ -446,7 +437,7 @@ static yyconst flex_int16_t yy_base[121] =
       174,    0,  164,    0,  229,  220,  222,   82,  224,  226
     } ;
 
-static yyconst flex_int16_t yy_def[121] =
+static const flex_int16_t yy_def[121] =
     {   0,
       115,    1,  115,  115,  115,  115,  115,  116,  117,  115,
       115,  115,  115,  115,  115,  115,  115,  115,  115,  115,
@@ -463,7 +454,7 @@ static yyconst flex_int16_t yy_def[121] =
       118,  118,  118,  118,    0,  115,  115,  115,  115,  115
     } ;
 
-static yyconst flex_int16_t yy_nxt[291] =
+static const flex_int16_t yy_nxt[291] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
        14,   15,   16,   17,   18,   19,   20,   21,   22,   23,
@@ -498,7 +489,7 @@ static yyconst flex_int16_t yy_nxt[291] =
       115,  115,  115,  115,  115,  115,  115,  115,  115,  115
     } ;
 
-static yyconst flex_int16_t yy_chk[291] =
+static const flex_int16_t yy_chk[291] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -564,7 +555,8 @@ int yycolumn = 1;
 #define YY_USER_ACTION yycolumn += yyleng; \
     tok.pos = yycolumn; \
     tok.s = strdup(yytext);
-#line 568 "lex.yy.c"
+#line 559 "lex.yy.c"
+#line 560 "lex.yy.c"
 
 #define INITIAL 0
 
@@ -580,36 +572,36 @@ int yycolumn = 1;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -617,35 +609,43 @@ void yyset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
-    static void yyunput (int c,char *buf_ptr  );
+#ifndef YY_NO_UNPUT
     
+    static void yyunput ( int c, char *buf_ptr  );
+    
+#endif
+
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -653,7 +653,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO fwrite( yytext, yyleng, 1, yyout )
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -664,7 +664,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		yy_size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -677,7 +677,7 @@ static int input (void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -732,7 +732,7 @@ extern int yylex (void);
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK break;
+#define YY_BREAK /*LINTED*/break;
 #endif
 
 #define YY_RULE_SETUP \
@@ -742,15 +742,10 @@ extern int yylex (void);
  */
 YY_DECL
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
     
-#line 19 "lexer.l"
-
-
-#line 753 "lex.yy.c"
-
 	if ( !(yy_init) )
 		{
 		(yy_init) = 1;
@@ -771,13 +766,19 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
-	while ( 1 )		/* loops until end-of-file is reached */
+	{
+#line 19 "lexer.l"
+
+
+#line 780 "lex.yy.c"
+
+	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
@@ -793,7 +794,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
 				(yy_last_accepting_state) = yy_current_state;
@@ -803,9 +804,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 116 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 229 );
@@ -1073,7 +1074,7 @@ YY_RULE_SETUP
 #line 87 "lexer.l"
 ECHO;
 	YY_BREAK
-#line 1077 "lex.yy.c"
+#line 1078 "lex.yy.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1151,7 +1152,7 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1204,6 +1205,7 @@ case YY_STATE_EOF(INITIAL):
 			"fatal flex scanner internal error--no action found" );
 	} /* end of action switch */
 		} /* end of scanning one token */
+	} /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
@@ -1215,9 +1217,9 @@ case YY_STATE_EOF(INITIAL):
  */
 static int yy_get_next_buffer (void)
 {
-    	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	register char *source = (yytext_ptr);
-	register int number_to_move, i;
+    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = (yytext_ptr);
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1246,7 +1248,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1259,21 +1261,21 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
 			{ /* Not enough room in the buffer - grow it. */
 
 			/* just a shorter name for the current buffer */
-			YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
+			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
 
 			int yy_c_buf_p_offset =
 				(int) ((yy_c_buf_p) - b->yy_ch_buf);
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1282,11 +1284,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1314,7 +1317,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1328,12 +1331,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1349,14 +1355,14 @@ static int yy_get_next_buffer (void)
 
     static yy_state_type yy_get_previous_state (void)
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
     
 	yy_current_state = (yy_start);
 
 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			(yy_last_accepting_state) = yy_current_state;
@@ -1366,9 +1372,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 116 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1381,10 +1387,10 @@ static int yy_get_next_buffer (void)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
-	register int yy_is_jam;
-    	register char *yy_cp = (yy_c_buf_p);
+	int yy_is_jam;
+    	char *yy_cp = (yy_c_buf_p);
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		(yy_last_accepting_state) = yy_current_state;
@@ -1394,17 +1400,19 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 116 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 115);
 
-	return yy_is_jam ? 0 : yy_current_state;
+		return yy_is_jam ? 0 : yy_current_state;
 }
 
-    static void yyunput (int c, register char * yy_bp )
+#ifndef YY_NO_UNPUT
+
+    static void yyunput (int c, char * yy_bp )
 {
-	register char *yy_cp;
+	char *yy_cp;
     
     yy_cp = (yy_c_buf_p);
 
@@ -1414,10 +1422,10 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register yy_size_t number_to_move = (yy_n_chars) + 2;
-		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
+		int number_to_move = (yy_n_chars) + 2;
+		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
 
 		while ( source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -1426,7 +1434,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -1438,6 +1446,8 @@ static int yy_get_next_buffer (void)
 	(yy_hold_char) = *yy_cp;
 	(yy_c_buf_p) = yy_cp;
 }
+
+#endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -1463,7 +1473,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1480,13 +1490,13 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( ) )
+					if ( yywrap(  ) )
 						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
@@ -1524,11 +1534,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
@@ -1556,7 +1566,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -1584,7 +1594,7 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
@@ -1593,13 +1603,13 @@ static void yy_load_buffer_state  (void)
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
@@ -1618,15 +1628,11 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
-#ifndef __cplusplus
-extern int isatty (int );
-#endif /* __cplusplus */
-    
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a yyrestart() or at EOF.
@@ -1636,7 +1642,7 @@ extern int isatty (int );
 {
 	int oerrno = errno;
     
-	yy_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1679,7 +1685,7 @@ extern int isatty (int );
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -1710,7 +1716,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -1729,7 +1735,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -1747,15 +1753,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1;
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -1764,7 +1770,7 @@ static void yyensure_buffer_stack (void)
 	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		int grow_size = 8 /* arbitrary grow size */;
+		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
@@ -1784,7 +1790,7 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
@@ -1794,23 +1800,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
@@ -1823,28 +1829,29 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return yy_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
- * @param bytes the byte buffer to scan
- * @param len the number of bytes in the buffer pointed to by @a bytes.
+ * @param yybytes the byte buffer to scan
+ * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
-	yy_size_t n, i;
+	yy_size_t n;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -1853,7 +1860,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -1869,9 +1876,9 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-    	(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -1899,7 +1906,7 @@ static void yy_fatal_error (yyconst char* msg )
  */
 int yyget_lineno  (void)
 {
-        
+    
     return yylineno;
 }
 
@@ -1922,7 +1929,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t yyget_leng  (void)
+int yyget_leng  (void)
 {
         return yyleng;
 }
@@ -1937,29 +1944,29 @@ char *yyget_text  (void)
 }
 
 /** Set the current line number.
- * @param line_number
+ * @param _line_number line number
  * 
  */
-void yyset_lineno (int  line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    yylineno = line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param in_str A readable stream.
+ * @param _in_str A readable stream.
  * 
  * @see yy_switch_to_buffer
  */
-void yyset_in (FILE *  in_str )
+void yyset_in (FILE *  _in_str )
 {
-        yyin = in_str ;
+        yyin = _in_str ;
 }
 
-void yyset_out (FILE *  out_str )
+void yyset_out (FILE *  _out_str )
 {
-        yyout = out_str ;
+        yyout = _out_str ;
 }
 
 int yyget_debug  (void)
@@ -1967,9 +1974,9 @@ int yyget_debug  (void)
         return yy_flex_debug;
 }
 
-void yyset_debug (int  bdebug )
+void yyset_debug (int  _bdebug )
 {
-        yy_flex_debug = bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
@@ -1978,10 +1985,10 @@ static int yy_init_globals (void)
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -1990,8 +1997,8 @@ static int yy_init_globals (void)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2006,7 +2013,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -2027,18 +2034,19 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
-	register int i;
+		
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 
@@ -2048,11 +2056,12 @@ static int yy_flex_strlen (yyconst char * s )
 
 void *yyalloc (yy_size_t  size )
 {
-	return (void *) malloc( size );
+			return malloc(size);
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
 {
+		
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -2060,18 +2069,17 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yyfree (void * ptr )
 {
-	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
 #line 87 "lexer.l"
-
 
 
 /**

--- a/src/query_executor.c
+++ b/src/query_executor.c
@@ -187,7 +187,7 @@ void inlineProperties(AST_Query *ast) {
             Vector_Get(properties, j+1, &val);
 
             const char *alias = entity->alias;
-            const char *property = key->stringval.str;
+            const char *property = key->stringval;
 
             AST_FilterNode *filterNode = New_AST_ConstantPredicateNode(alias, property, EQ, *val);
             

--- a/src/resultset/record.c
+++ b/src/resultset/record.c
@@ -33,8 +33,15 @@ Record* Record_FromGroup(const ResultSetHeader *resultset_header, const Group *g
     return r;
 }
 
-size_t Record_ToString(const Record *record, char **record_str) {
-  return SIValue_StringConcat(record->values, record->len, record_str);
+size_t Record_ToString(const Record *record, char **buf, size_t *buf_cap) {
+    size_t required_len = SIValue_StringConcatLen(record->values, record->len);
+
+    if(*buf_cap < required_len) {
+        *buf = realloc(*buf, sizeof(char) * required_len);
+        *buf_cap = required_len;
+    }
+
+    return SIValue_StringConcat(record->values, record->len, *buf, *buf_cap);
 }
 
 int Records_Compare(const Record *A, const Record *B, int* compareIndices, size_t compareIndicesLen) {

--- a/src/resultset/record.c
+++ b/src/resultset/record.c
@@ -33,15 +33,8 @@ Record* Record_FromGroup(const ResultSetHeader *resultset_header, const Group *g
     return r;
 }
 
-size_t Record_ToString(const Record *record, char **buf, size_t *buf_cap) {
-    size_t required_len = SIValue_StringConcatLen(record->values, record->len);
-    
-    if(*buf_cap < required_len) {
-        *buf = realloc(*buf, sizeof(char) * required_len);
-        *buf_cap = required_len;
-    }
-
-    return SIValue_StringConcat(record->values, record->len, *buf, *buf_cap);
+size_t Record_ToString(const Record *record, char **record_str) {
+  return SIValue_StringConcat(record->values, record->len, record_str);
 }
 
 int Records_Compare(const Record *A, const Record *B, int* compareIndices, size_t compareIndicesLen) {

--- a/src/resultset/record.h
+++ b/src/resultset/record.h
@@ -17,7 +17,7 @@ Record* NewRecord(size_t len);
 Record* Record_FromGroup(const ResultSetHeader *resultset_header, const Group *g);
 
 /* Get a string representation of record. */
-size_t Record_ToString(const Record *record, char **buf, size_t *buf_cap);
+size_t Record_ToString(const Record *record, char **record_str);
 
 /* Compares the two records, using the values at given indeces
  * Returns 1 if A >= B, -1 if A <= B, 0 if A = B */

--- a/src/resultset/record.h
+++ b/src/resultset/record.h
@@ -17,7 +17,7 @@ Record* NewRecord(size_t len);
 Record* Record_FromGroup(const ResultSetHeader *resultset_header, const Group *g);
 
 /* Get a string representation of record. */
-size_t Record_ToString(const Record *record, char **record_str);
+size_t Record_ToString(const Record *record, char **buf, size_t *buf_cap);
 
 /* Compares the two records, using the values at given indeces
  * Returns 1 if A >= B, -1 if A <= B, 0 if A = B */

--- a/src/stores/store_type.c
+++ b/src/stores/store_type.c
@@ -37,7 +37,7 @@ void StoreType_RdbSave(RedisModuleIO *rdb, void *value) {
     LabelStore *s = value;
 
     RedisModule_SaveUnsigned(rdb, s->id);
-    RedisModule_SaveStringBuffer(rdb, s->label, strlen(s->label));
+    RedisModule_SaveStringBuffer(rdb, s->label, strlen(s->label) + 1);
     RedisModule_SaveUnsigned(rdb, s->properties->cardinality);
 
     if(s->properties->cardinality) {

--- a/src/value.c
+++ b/src/value.c
@@ -159,7 +159,7 @@ int SI_ParseValue(SIValue *v, char *str) {
   switch (v->type) {
 
   case T_STRING:
-    v->stringval = str;
+    v->stringval = strdup(str);
 
     break;
   case T_INT32:

--- a/src/value.c
+++ b/src/value.c
@@ -358,25 +358,20 @@ int SIValue_ToDouble(SIValue *v, double *d) {
   }
 }
 
-void SIValue_FromString(SIValue *v, char *s) {
-  int numeric = 1;
-  char *c;
+SIValue SIValue_FromString(char *s) {
+  char *sEnd = NULL;
 
-  /* Scan string, see if we can find any non-numeric characters in it. */
-  for(c = s; *c != '\0'; c ++) {
-    
-    if(!isdigit(*c) && *c != '.' && *c != '-') {
-      numeric = 0;
-      v->type = T_STRING;
-      break;
-    }
+  errno = 0;
+  double parsedval = strtod (s, &sEnd);
+  /* The input was not a complete number or represented a number that
+   * cannot be represented as a double.
+   * Create a string SIValue. */
+  if (sEnd[0] != '\0' || errno == ERANGE) {
+    return SI_StringVal(s);
   }
 
-  if(numeric) {
-    v->type = T_DOUBLE;
-  }
-
-  SI_ParseValue(v, s);
+  // The input was fully converted; create a double SIValue.
+  return SI_DoubleVal(parsedval);
 }
 
 size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char** concat) {

--- a/src/value.c
+++ b/src/value.c
@@ -374,31 +374,33 @@ SIValue SIValue_FromString(const char *s) {
   return SI_DoubleVal(parsedval);
 }
 
-size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char** concat) {
-  int i;
+size_t SIValue_StringConcatLen(SIValue* strings, unsigned int string_count) {
+  size_t length = 0;
+  size_t elem_len;
 
-  size_t offset = 0, length = 0;
   /* Compute length. */
-  for(i = 0; i < string_count; i++) {
-    /* Element string representation bytes size, strings are
-    * surrounded by double quotes,
-    * for all other SIValue types 32 bytes should be enough. */
-    size_t len = (strings[i].type == T_STRING) ? strlen(strings[i].stringval) + 2 : 32;
-    length += len;
+  for(int i = 0; i < string_count; i ++) {
+    /* String elements representing bytes size strings,
+     * for all other SIValue types 32 bytes should be enough. */
+    elem_len = (strings[i].type == T_STRING) ? strlen(strings[i].stringval) + 1 : 32;
+    length += elem_len;
   }
 
-  /* Account for delimiters and NULL terminating byte. */
+  /* Account for NULL terminating byte. */
   length += string_count + 1;
-  *concat = malloc(length * sizeof(char));
+  return length;
+}
 
-  for(i = 0; i < string_count; i++) {
-    offset += SIValue_ToString(strings[i], (*concat) + offset, length - offset - 1);
-    (*concat)[offset++] = ',';
+size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *buf, size_t buf_len) {
+  size_t offset = 0;
+
+  for (int i = 0; i < string_count; i ++) {
+    offset += SIValue_ToString(strings[i], buf + offset, buf_len - offset - 1);
+    buf[offset++] = ',';
   }
-  /* Backtrack once. */
-  (*concat)[-- offset] = '\0';
+  /* Backtrack once and discard last delimiter. */
+  buf[--offset] = '\0';
 
-  /* Discard last delimiter. */
   return offset;
 }
 

--- a/src/value.c
+++ b/src/value.c
@@ -358,7 +358,7 @@ int SIValue_ToDouble(SIValue *v, double *d) {
   }
 }
 
-SIValue SIValue_FromString(char *s) {
+SIValue SIValue_FromString(const char *s) {
   char *sEnd = NULL;
 
   errno = 0;

--- a/src/value.c
+++ b/src/value.c
@@ -362,7 +362,7 @@ SIValue SIValue_FromString(char *s) {
   char *sEnd = NULL;
 
   errno = 0;
-  double parsedval = strtod (s, &sEnd);
+  double parsedval = strtod(s, &sEnd);
   /* The input was not a complete number or represented a number that
    * cannot be represented as a double.
    * Create a string SIValue. */

--- a/src/value.h
+++ b/src/value.h
@@ -94,7 +94,7 @@ int SIValue_ToString(SIValue v, char *buf, size_t len);
 int SIValue_ToDouble(SIValue *v, double *d);
 
 /* Try to parse a value by string. */
-SIValue SIValue_FromString(char *s);
+SIValue SIValue_FromString(const char *s);
 
 /* Concats strings as a comma seperated string. */
 size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char** concat);

--- a/src/value.h
+++ b/src/value.h
@@ -2,6 +2,7 @@
 #define __SECONDARY_VALUE_H__
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 #include "./rmutil/vector.h"
 
 typedef char *SIId;
@@ -27,15 +28,6 @@ typedef enum {
 
 #define SI_NUMERIC (T_INT32 | T_INT64 | T_UINT | T_FLOAT | T_DOUBLE)
 
-// binary safe strings
-typedef struct {
-  char *str;
-  size_t len;
-} SIString;
-
-SIString SI_WrapString(const char *s);
-SIString SIString_Copy(SIString s);
-
 typedef struct {
   union {
     int32_t intval;
@@ -44,7 +36,7 @@ typedef struct {
     float floatval;
     double doubleval;
     int boolval;
-    SIString stringval;
+    char *stringval;
     void* ptrval;
   };
   SIType type;
@@ -66,8 +58,7 @@ void SIValue_Free(SIValue *v);
 void SIValueVector_Append(SIValueVector *v, SIValue val);
 void SIValueVector_Free(SIValueVector *v);
 
-SIValue SI_StringVal(SIString s);
-SIValue SI_StringValC(char *s);
+SIValue SI_StringVal(const char *s);
 SIValue SI_IntVal(int i);
 SIValue SI_LongVal(int64_t i);
 SIValue SI_UintVal(u_int64_t i);
@@ -96,23 +87,22 @@ int SI_StringVal_Cast(SIValue *v, SIType type);
 
 /* Try to parse a value by string. The value's type should be set to
 * anything other than T_NULL, to force strict parsing. */
-int SI_ParseValue(SIValue *v, char *str, size_t len);
+int SI_ParseValue(SIValue *v, char *str);
 
 int SIValue_ToString(SIValue v, char *buf, size_t len);
 
 int SIValue_ToDouble(SIValue *v, double *d);
 
 /* Try to parse a value by string. */
-void SIValue_FromString(SIValue *v, char *s, size_t s_len);
-
-/* Determins number of bytes required to concat strings. */
-size_t SIValue_StringConcatLen(SIValue* strings, unsigned int string_count);
+void SIValue_FromString(SIValue *v, char *s);
 
 /* Concats strings as a comma seperated string. */
-size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char* buf, size_t buf_len);
+size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char** concat);
 
 /* Compares two SIValues, expecting a and b to be of the same type,
  * return value is similar to strcmp. */
 int SIValue_Compare(SIValue a, SIValue b);
+
+void SIValue_Print(FILE *outstream, SIValue *v);
 
 #endif

--- a/src/value.h
+++ b/src/value.h
@@ -94,7 +94,7 @@ int SIValue_ToString(SIValue v, char *buf, size_t len);
 int SIValue_ToDouble(SIValue *v, double *d);
 
 /* Try to parse a value by string. */
-void SIValue_FromString(SIValue *v, char *s);
+SIValue SIValue_FromString(char *s);
 
 /* Concats strings as a comma seperated string. */
 size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char** concat);

--- a/src/value.h
+++ b/src/value.h
@@ -96,8 +96,11 @@ int SIValue_ToDouble(SIValue *v, double *d);
 /* Try to parse a value by string. */
 SIValue SIValue_FromString(const char *s);
 
-/* Concats strings as a comma seperated string. */
-size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char** concat);
+/* Determines number of bytes required to concat strings. */
+size_t SIValue_StringConcatLen(SIValue* strings, unsigned int string_count);
+
+/* Concats strings as a comma separated string. */
+size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *buf, size_t buf_len);
 
 /* Compares two SIValues, expecting a and b to be of the same type,
  * return value is similar to strcmp. */

--- a/src/value_cmp.c
+++ b/src/value_cmp.c
@@ -19,15 +19,17 @@ int cmp_string(void *p1, void *p2) {
     return -1;
 
 
+  int v1_len = strlen(v1->stringval);
+  int v2_len = strlen(v2->stringval);
   // compare the longest length possible, which is the shortest length of the
   // two strings
-  int cmp = strncasecmp(v1->stringval.str, v2->stringval.str,
-                    MIN(v2->stringval.len, v1->stringval.len));
+  int cmp = strncasecmp(v1->stringval, v2->stringval,
+                    MIN(v1_len, v2_len));
 
   // if the strings are equal at the common length but are not of the same
   // length, the longer string wins
-  if (cmp == 0 && v1->stringval.len != v2->stringval.len) {
-    return v1->stringval.len > v2->stringval.len ? 1 : -1;
+  if (cmp == 0 && v1_len != v2_len) {
+    return v1_len > v2_len ? 1 : -1;
   }
   // if they are not equal, or equal and same length - return the original cmp
   return cmp;

--- a/src/value_cmp.c
+++ b/src/value_cmp.c
@@ -12,25 +12,5 @@ GENERIC_CMP_FUNC_IMPL(cmp_double, doubleval);
 GENERIC_CMP_FUNC_IMPL(cmp_uint, uintval);
 
 int cmp_string(void *p1, void *p2) {
-  SIValue *v1 = p1, *v2 = p2;
-  if (SIValue_IsInf(v1) || SIValue_IsNegativeInf(v2))
-    return 1;
-  if (SIValue_IsInf(v2) || SIValue_IsNegativeInf(v1))
-    return -1;
-
-
-  int v1_len = strlen(v1->stringval);
-  int v2_len = strlen(v2->stringval);
-  // compare the longest length possible, which is the shortest length of the
-  // two strings
-  int cmp = strncasecmp(v1->stringval, v2->stringval,
-                    MIN(v1_len, v2_len));
-
-  // if the strings are equal at the common length but are not of the same
-  // length, the longer string wins
-  if (cmp == 0 && v1_len != v2_len) {
-    return v1_len > v2_len ? 1 : -1;
-  }
-  // if they are not equal, or equal and same length - return the original cmp
-  return cmp;
+  return strcasecmp(((SIValue*)p1)->stringval, ((SIValue*)p2)->stringval);
 }

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -25,7 +25,10 @@ tuples_iter: test_tuples_iter.o
 filter_tree: test_filter_tree.o
 	$(CC) $(CFLAGS) -o test_filter_tree test_filter_tree.o  $(DEPS) $(LDFLAGS)
 
-build: graph algebraic_expression tuples_iter filter_tree
+value: test_value.o
+	$(CC) $(CFLAGS)  -o test_value test_value.o  $(DEPS) $(LDFLAGS)
+
+build: graph algebraic_expression tuples_iter filter_tree value
 
 test_graph:
 	@(sh -c ./test_graph)
@@ -43,6 +46,10 @@ test_filter_tree:
 	@(sh -c ./test_filter_tree)
 .PHONY: test_filter_tree
 
-test: test_graph test_algebraic_expression test_tuples_iter test_filter_tree
+test_value:
+	@(sh -c ./test_value)
+.PHONY: test_value
+
+test: test_graph test_algebraic_expression test_tuples_iter test_filter_tree test_value
 
 all: build test

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -28,7 +28,10 @@ filter_tree: test_filter_tree.o
 value: test_value.o
 	$(CC) $(CFLAGS)  -o test_value test_value.o  $(DEPS) $(LDFLAGS)
 
-build: graph algebraic_expression tuples_iter filter_tree value
+arithmetic_expression: test_arithmetic_expression.o
+	$(CC) $(CFLAGS)  -o test_arithmetic_expression test_arithmetic_expression.o  $(DEPS) $(LDFLAGS)
+
+build: graph algebraic_expression tuples_iter filter_tree value arithmetic_expression
 
 test_graph:
 	@(sh -c ./test_graph)
@@ -50,6 +53,10 @@ test_value:
 	@(sh -c ./test_value)
 .PHONY: test_value
 
-test: test_graph test_algebraic_expression test_tuples_iter test_filter_tree test_value
+test_arithmetic_expression:
+	@(sh -c ./test_arithmetic_expression)
+.PHONY: test_arithmetic_expression
+
+test: test_graph test_algebraic_expression test_tuples_iter test_filter_tree test_value test_arithmetic_expression
 
 all: build test

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -31,7 +31,10 @@ value: test_value.o
 arithmetic_expression: test_arithmetic_expression.o
 	$(CC) $(CFLAGS)  -o test_arithmetic_expression test_arithmetic_expression.o  $(DEPS) $(LDFLAGS)
 
-build: graph algebraic_expression tuples_iter filter_tree value arithmetic_expression
+resultset_record: test_resultset_record.o
+	$(CC) $(CFLAGS)  -o test_resultset_record test_resultset_record.o  $(DEPS) $(LDFLAGS)
+
+build: graph algebraic_expression tuples_iter filter_tree value arithmetic_expression resultset_record
 
 test_graph:
 	@(sh -c ./test_graph)
@@ -57,6 +60,10 @@ test_arithmetic_expression:
 	@(sh -c ./test_arithmetic_expression)
 .PHONY: test_arithmetic_expression
 
-test: test_graph test_algebraic_expression test_tuples_iter test_filter_tree test_value test_arithmetic_expression
+test_resultset_record:
+	@(sh -c ./test_resultset_record)
+.PHONY: test_resultset_record
+
+test: test_graph test_algebraic_expression test_tuples_iter test_filter_tree test_value test_arithmetic_expression test_resultset_record
 
 all: build test

--- a/tests/unit/test_algebraic_expression.c
+++ b/tests/unit/test_algebraic_expression.c
@@ -99,12 +99,12 @@ Graph *_build_graph() {
     char *default_property_name = "name";
     for(int i = 0; i < person_count; i++) {
         Node *n = NodeIterator_Next(it);
-        SIValue name = SI_StringValC(persons[i]);
+        SIValue name = SI_StringVal(persons[i]);
         Node_Add_Properties(n, 1, &default_property_name, &name);
     }
     for(int i = 0; i < country_count; i++) {
         Node *n = NodeIterator_Next(it);
-        SIValue name = SI_StringValC(countries[i]);
+        SIValue name = SI_StringVal(countries[i]);
         Node_Add_Properties(n, 1, &default_property_name, &name);
     }
 

--- a/tests/unit/test_arithmetic_expression.c
+++ b/tests/unit/test_arithmetic_expression.c
@@ -84,7 +84,7 @@ void test_arithmetic_expression() {
 
 void test_variadic_arithmetic_expression() {
     /* person.age += 1 */
-    Node *node = NewNode(1, "person");
+    Node *node = Node_New(1, "person");
     char *props[2] = {"age", "name"};
     SIValue vals[2] = {SI_DoubleVal(33), SI_StringVal("joe")};
     GraphEntity_Add_Properties((GraphEntity*)node, 2, props, vals);
@@ -601,7 +601,7 @@ void test_trim() {
 void test_id() {
     AR_ExpNode *root = AR_EXP_NewOpNode("id", 1);
 
-    Node *node = NewNode(12345, "person");
+    Node *node = Node_New(12345, "person");
     AR_ExpNode *person_with_id = AR_EXP_NewVariableOperandNode((GraphEntity **)(&node), NULL, "Joe");
 
     root->op.children[0] = person_with_id;

--- a/tests/unit/test_arithmetic_expression.c
+++ b/tests/unit/test_arithmetic_expression.c
@@ -9,9 +9,9 @@
 void test_arithmetic_expression() {
 
     /* muchacho */
-    AR_ExpNode *string = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho"));
+    AR_ExpNode *string = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho"));
     SIValue result = AR_EXP_Evaluate(string);
-    assert(strcmp(result.stringval.str, "muchacho") == 0);
+    assert(strcmp(result.stringval, "muchacho") == 0);
     AR_EXP_Free(string);
 
     /* 1 */
@@ -86,7 +86,7 @@ void test_variadic_arithmetic_expression() {
     /* person.age += 1 */
     Node *node = NewNode(1, "person");
     char *props[2] = {"age", "name"};
-    SIValue vals[2] = {SI_DoubleVal(33), SI_StringValC("joe")};
+    SIValue vals[2] = {SI_DoubleVal(33), SI_StringVal("joe")};
     GraphEntity_Add_Properties((GraphEntity*)node, 2, props, vals);
 
     AR_ExpNode *one = AR_EXP_NewConstOperandNode(SI_DoubleVal(1));
@@ -337,7 +337,7 @@ void test_sign() {
 
 void test_left() {
     AR_ExpNode *root = AR_EXP_NewOpNode("LEFT", 2);
-    AR_ExpNode *str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho"));
+    AR_ExpNode *str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho"));
     AR_ExpNode *left = AR_EXP_NewConstOperandNode(SI_DoubleVal(4));
     AR_ExpNode *entire_string_len = AR_EXP_NewConstOperandNode(SI_DoubleVal(100));
     AR_ExpNode *null = AR_EXP_NewConstOperandNode(SI_NullVal());
@@ -346,13 +346,13 @@ void test_left() {
     root->op.children[1] = left;
     SIValue result = AR_EXP_Evaluate(root);
     char *expected = "much";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = str;
     root->op.children[1] = entire_string_len;
     result = AR_EXP_Evaluate(root);
     expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = null;
     root->op.children[1] = entire_string_len;
@@ -362,19 +362,19 @@ void test_left() {
 
 void test_reverse() {
     AR_ExpNode *root = AR_EXP_NewOpNode("REVERSE", 1);
-    AR_ExpNode *str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho"));
-    AR_ExpNode *empty_str = AR_EXP_NewConstOperandNode(SI_StringValC(""));
+    AR_ExpNode *str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho"));
+    AR_ExpNode *empty_str = AR_EXP_NewConstOperandNode(SI_StringVal(""));
     AR_ExpNode *null = AR_EXP_NewConstOperandNode(SI_NullVal());
     
     root->op.children[0] = str;
     SIValue result = AR_EXP_Evaluate(root);
     char *expected = "ohcahcum";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = empty_str;
     result = AR_EXP_Evaluate(root);
     expected = "";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = null;
     result = AR_EXP_Evaluate(root);
@@ -383,7 +383,7 @@ void test_reverse() {
 
 void test_right() {
     AR_ExpNode *root = AR_EXP_NewOpNode("RIGHT", 2);
-    AR_ExpNode *str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho"));
+    AR_ExpNode *str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho"));
     AR_ExpNode *right = AR_EXP_NewConstOperandNode(SI_DoubleVal(4));
     AR_ExpNode *entire_string_len = AR_EXP_NewConstOperandNode(SI_DoubleVal(100));
     AR_ExpNode *null = AR_EXP_NewConstOperandNode(SI_NullVal());
@@ -392,13 +392,13 @@ void test_right() {
     root->op.children[1] = right;
     SIValue result = AR_EXP_Evaluate(root);
     char *expected = "acho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = str;
     root->op.children[1] = entire_string_len;
     result = AR_EXP_Evaluate(root);
     expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = null;
     root->op.children[1] = entire_string_len;
@@ -408,31 +408,31 @@ void test_right() {
 
 void test_ltrim() {
     AR_ExpNode *root = AR_EXP_NewOpNode("lTrim", 1);
-    AR_ExpNode *left_spaced_str = AR_EXP_NewConstOperandNode(SI_StringValC("   muchacho"));
-    AR_ExpNode *right_spaced_str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho   "));
-    AR_ExpNode *spaced_str = AR_EXP_NewConstOperandNode(SI_StringValC("   much   acho   "));
-    AR_ExpNode *no_space_str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho"));
+    AR_ExpNode *left_spaced_str = AR_EXP_NewConstOperandNode(SI_StringVal("   muchacho"));
+    AR_ExpNode *right_spaced_str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho   "));
+    AR_ExpNode *spaced_str = AR_EXP_NewConstOperandNode(SI_StringVal("   much   acho   "));
+    AR_ExpNode *no_space_str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho"));
     AR_ExpNode *null = AR_EXP_NewConstOperandNode(SI_NullVal());
 
     root->op.children[0] = left_spaced_str;
     SIValue result = AR_EXP_Evaluate(root);
     char *expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = right_spaced_str;
     result = AR_EXP_Evaluate(root);
     expected = "muchacho   ";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = spaced_str;
     result = AR_EXP_Evaluate(root);
     expected = "much   acho   ";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = no_space_str;
     result = AR_EXP_Evaluate(root);
     expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = null;
     result = AR_EXP_Evaluate(root);
@@ -441,31 +441,31 @@ void test_ltrim() {
 
 void test_rtrim() {
     AR_ExpNode *root = AR_EXP_NewOpNode("rTrim", 1);
-    AR_ExpNode *left_spaced_str = AR_EXP_NewConstOperandNode(SI_StringValC("   muchacho"));
-    AR_ExpNode *right_spaced_str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho   "));
-    AR_ExpNode *spaced_str = AR_EXP_NewConstOperandNode(SI_StringValC("   much   acho   "));
-    AR_ExpNode *no_space_str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho"));
+    AR_ExpNode *left_spaced_str = AR_EXP_NewConstOperandNode(SI_StringVal("   muchacho"));
+    AR_ExpNode *right_spaced_str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho   "));
+    AR_ExpNode *spaced_str = AR_EXP_NewConstOperandNode(SI_StringVal("   much   acho   "));
+    AR_ExpNode *no_space_str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho"));
     AR_ExpNode *null = AR_EXP_NewConstOperandNode(SI_NullVal());
 
     root->op.children[0] = left_spaced_str;
     SIValue result = AR_EXP_Evaluate(root);
     char *expected = "   muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = right_spaced_str;
     result = AR_EXP_Evaluate(root);
     expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = spaced_str;
     result = AR_EXP_Evaluate(root);
     expected = "   much   acho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = no_space_str;
     result = AR_EXP_Evaluate(root);
     expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = null;
     result = AR_EXP_Evaluate(root);
@@ -474,7 +474,7 @@ void test_rtrim() {
 
 void test_substring() {
     AR_ExpNode *root = AR_EXP_NewOpNode("SUBSTRING", 3);
-    AR_ExpNode *original_str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho"));
+    AR_ExpNode *original_str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho"));
     AR_ExpNode *start = AR_EXP_NewConstOperandNode(SI_DoubleVal(0));
     AR_ExpNode *length = AR_EXP_NewConstOperandNode(SI_DoubleVal(4));
     AR_ExpNode *start_middel = AR_EXP_NewConstOperandNode(SI_DoubleVal(3));
@@ -486,14 +486,14 @@ void test_substring() {
     root->op.children[2] = length;
     SIValue result = AR_EXP_Evaluate(root);
     char *expected = "much";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = original_str;
     root->op.children[1] = start_middel;
     root->op.children[2] = length_overflow;
     result = AR_EXP_Evaluate(root);
     expected = "hacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = null;
     root->op.children[1] = start_middel;
@@ -504,19 +504,19 @@ void test_substring() {
 
 void test_tolower() {
     AR_ExpNode *root = AR_EXP_NewOpNode("toLower", 1);
-    AR_ExpNode *str1 = AR_EXP_NewConstOperandNode(SI_StringValC("MuChAcHo"));
-    AR_ExpNode *str2 = AR_EXP_NewConstOperandNode(SI_StringValC("mUcHaChO"));
+    AR_ExpNode *str1 = AR_EXP_NewConstOperandNode(SI_StringVal("MuChAcHo"));
+    AR_ExpNode *str2 = AR_EXP_NewConstOperandNode(SI_StringVal("mUcHaChO"));
     AR_ExpNode *null = AR_EXP_NewConstOperandNode(SI_NullVal());
 
     root->op.children[0] = str1;    
     SIValue result = AR_EXP_Evaluate(root);
     char *expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = str2;
     result = AR_EXP_Evaluate(root);
     expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = null;
     result = AR_EXP_Evaluate(root);
@@ -525,19 +525,19 @@ void test_tolower() {
 
 void test_toupper() {
     AR_ExpNode *root = AR_EXP_NewOpNode("toUpper", 1);
-    AR_ExpNode *str1 = AR_EXP_NewConstOperandNode(SI_StringValC("MuChAcHo"));
-    AR_ExpNode *str2 = AR_EXP_NewConstOperandNode(SI_StringValC("mUcHaChO"));
+    AR_ExpNode *str1 = AR_EXP_NewConstOperandNode(SI_StringVal("MuChAcHo"));
+    AR_ExpNode *str2 = AR_EXP_NewConstOperandNode(SI_StringVal("mUcHaChO"));
     AR_ExpNode *null = AR_EXP_NewConstOperandNode(SI_NullVal());
 
     root->op.children[0] = str1;
     SIValue result = AR_EXP_Evaluate(root);
     char *expected = "MUCHACHO";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = str2;
     result = AR_EXP_Evaluate(root);
     expected = "MUCHACHO";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = null;
     result = AR_EXP_Evaluate(root);
@@ -546,19 +546,19 @@ void test_toupper() {
 
 void test_toString() {
     AR_ExpNode *root = AR_EXP_NewOpNode("toString", 1);
-    AR_ExpNode *str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho"));
+    AR_ExpNode *str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho"));
     AR_ExpNode *number = AR_EXP_NewConstOperandNode(SI_DoubleVal(3.14));
     AR_ExpNode *null = AR_EXP_NewConstOperandNode(SI_NullVal());
 
     root->op.children[0] = str;
     SIValue result = AR_EXP_Evaluate(root);
     char *expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = number;
     result = AR_EXP_Evaluate(root);
     expected = "3.140000";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = null;
     result = AR_EXP_Evaluate(root);
@@ -567,31 +567,31 @@ void test_toString() {
 
 void test_trim() {
     AR_ExpNode *root = AR_EXP_NewOpNode("trim", 1);
-    AR_ExpNode *left_spaced_str = AR_EXP_NewConstOperandNode(SI_StringValC("   muchacho"));
-    AR_ExpNode *right_spaced_str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho   "));
-    AR_ExpNode *spaced_str = AR_EXP_NewConstOperandNode(SI_StringValC("   much   acho   "));
-    AR_ExpNode *no_space_str = AR_EXP_NewConstOperandNode(SI_StringValC("muchacho"));
+    AR_ExpNode *left_spaced_str = AR_EXP_NewConstOperandNode(SI_StringVal("   muchacho"));
+    AR_ExpNode *right_spaced_str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho   "));
+    AR_ExpNode *spaced_str = AR_EXP_NewConstOperandNode(SI_StringVal("   much   acho   "));
+    AR_ExpNode *no_space_str = AR_EXP_NewConstOperandNode(SI_StringVal("muchacho"));
     AR_ExpNode *null = AR_EXP_NewConstOperandNode(SI_NullVal());
 
     root->op.children[0] = left_spaced_str;
     SIValue result = AR_EXP_Evaluate(root);
     char *expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = right_spaced_str;
     result = AR_EXP_Evaluate(root);
     expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = spaced_str;
     result = AR_EXP_Evaluate(root);
     expected = "much   acho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = no_space_str;
     result = AR_EXP_Evaluate(root);
     expected = "muchacho";
-    assert(strcmp(result.stringval.str, expected) == 0);
+    assert(strcmp(result.stringval, expected) == 0);
 
     root->op.children[0] = null;
     result = AR_EXP_Evaluate(root);

--- a/tests/unit/test_node.c
+++ b/tests/unit/test_node.c
@@ -21,12 +21,12 @@ void test_node_props() {
 	Node *node = NewNode(1l, "city");
 
 	char *keys[2] = {"neighborhood", "block"};
-	SIValue vals[2] = { SI_StringValC("rambam"), SI_IntVal(10)};
+	SIValue vals[2] = { SI_StringVal("rambam"), SI_IntVal(10)};
 
 	GraphEntity_Add_Properties((GraphEntity*)node, 2, keys, vals);
 
 	SIValue *val = GraphEntity_Get_Property((GraphEntity*)node, "neighborhood");
-	assert(strcmp(val->stringval.str, "rambam") == 0);
+	assert(strcmp(val->stringval, "rambam") == 0);
 
 	val = GraphEntity_Get_Property((GraphEntity*)node, "block");
 	assert(val->intval == 10);

--- a/tests/unit/test_resultset_record.c
+++ b/tests/unit/test_resultset_record.c
@@ -3,9 +3,7 @@
 #include "../../src/resultset/record.h"
 #include "../../src/value.h"
 
-size_t Record_ToString(const Record *record, char **record_str);
-
-void test_record_to_string () {
+void test_record_to_string() {
     Record *record = NewRecord(6);    
     SIValue v_string = SI_StringVal("Hello");
     SIValue v_int = SI_IntVal(-24);
@@ -21,12 +19,14 @@ void test_record_to_string () {
     record->values[4] = v_null;
     record->values[5] = v_bool;
 
-    char *record_str;
-    size_t record_str_len = Record_ToString(record, &record_str);
+    size_t record_str_cap = 0;
+    char *record_str = NULL;
+    size_t record_str_len = Record_ToString(record, &record_str, &record_str_cap);
 
     assert(strcmp(record_str, "Hello,-24,24,0.314000,NULL,true") == 0);
     assert(record_str_len == 31);
     
+    SIValue_Free(&v_string);
     free(record_str);
     Record_Free(record);
 }

--- a/tests/unit/test_resultset_record.c
+++ b/tests/unit/test_resultset_record.c
@@ -7,7 +7,7 @@ size_t Record_ToString(const Record *record, char **record_str);
 
 void test_record_to_string () {
     Record *record = NewRecord(6);    
-    SIValue v_string = SI_StringValC("Hello");
+    SIValue v_string = SI_StringVal("Hello");
     SIValue v_int = SI_IntVal(-24);
     SIValue v_uint = SI_UintVal(24);
     SIValue v_float = SI_FloatVal(0.314);

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -6,26 +6,26 @@
 void test_value_parse() {
     SIValue v;
     char *str = "12345";
-    SIValue_FromString(&v, str, strlen(str));
+    SIValue_FromString(&v, str);
     assert(v.type == T_DOUBLE);
     assert(v.doubleval == 12345);
 
     str = "3.14";
-    SIValue_FromString(&v, str, strlen(str));
+    SIValue_FromString(&v, str);
     assert(v.type == T_DOUBLE);
     
     /* Almost equals. */
     assert((v.doubleval - 3.14) < 0.0001);
 
     str = "-9876";
-    SIValue_FromString(&v, str, strlen(str));
+    SIValue_FromString(&v, str);
     assert(v.type == T_DOUBLE);
     assert(v.doubleval == -9876);
 
     str = "Test!";
-    SIValue_FromString(&v, str, strlen(str));
+    SIValue_FromString(&v, str);
     assert(v.type == T_STRING);
-    assert(strcmp(v.stringval.str, "Test!") == 0);
+    assert(strcmp(v.stringval, "Test!") == 0);
 }
 
 int main(int argc, char **argv) {

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -6,24 +6,24 @@
 void test_value_parse() {
     SIValue v;
     char *str = "12345";
-    SIValue_FromString(&v, str);
+    v = SIValue_FromString(str);
     assert(v.type == T_DOUBLE);
     assert(v.doubleval == 12345);
 
     str = "3.14";
-    SIValue_FromString(&v, str);
+    v = SIValue_FromString(str);
     assert(v.type == T_DOUBLE);
     
     /* Almost equals. */
     assert((v.doubleval - 3.14) < 0.0001);
 
     str = "-9876";
-    SIValue_FromString(&v, str);
+    v = SIValue_FromString(str);
     assert(v.type == T_DOUBLE);
     assert(v.doubleval == -9876);
 
     str = "Test!";
-    SIValue_FromString(&v, str);
+    v = SIValue_FromString(str);
     assert(v.type == T_STRING);
     assert(strcmp(v.stringval, "Test!") == 0);
 }

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -26,6 +26,17 @@ void test_value_parse() {
     v = SIValue_FromString(str);
     assert(v.type == T_STRING);
     assert(strcmp(v.stringval, "Test!") == 0);
+
+    str = "+1.0E1";
+    v = SIValue_FromString(str);
+    assert(v.type == T_DOUBLE);
+    assert(v.doubleval == 10);
+
+    /* Out of double range */
+    str = "1.0001e10001";
+    v = SIValue_FromString(str);
+    assert(v.type == T_STRING);
+    assert(strcmp(v.stringval, "1.0001e10001") == 0);
 }
 
 int main(int argc, char **argv) {

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -26,6 +26,7 @@ void test_value_parse() {
     v = SIValue_FromString(str);
     assert(v.type == T_STRING);
     assert(strcmp(v.stringval, "Test!") == 0);
+    SIValue_Free(&v);
 
     str = "+1.0E1";
     v = SIValue_FromString(str);
@@ -37,6 +38,7 @@ void test_value_parse() {
     v = SIValue_FromString(str);
     assert(v.type == T_STRING);
     assert(strcmp(v.stringval, "1.0001e10001") == 0);
+    SIValue_Free(&v);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This PR replaces the `SIString` member of the `SIValue` union with a `char *`, as (to the best of my knowledge) Redis-Graph only ever uses null-terminated strings.

Making this change reduces the size of the `SIValue` struct from 24 to 16 bytes.

The code contained in this PR has been live on the swilly22/master for a few months, so I don't believe this change should have any negative consequences.