### PR TITLE
Only resize NodeBlock count by integer multiples

### DIFF
--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -43,7 +43,7 @@ void _Graph_ResizeNodes(Graph *g, size_t n) {
     int last_block = g->block_count - 1;
 
     // Increase NodeBlock count by the smallest multiple required to contain all nodes
-    int increase_factor = (total_nodes / g->node_cap) + 1;
+    int increase_factor = (total_nodes / g->node_cap) + 2;
     g->block_count *= increase_factor;
 
     g->nodes_blocks = realloc(g->nodes_blocks, sizeof(NodeBlock*) * g->block_count);

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -34,20 +34,19 @@ void _Graph_ResizeMatrix(const Graph *g, GrB_Matrix m) {
 
 // Resize graph's node array to contain at least n nodes.
 void _Graph_ResizeNodes(Graph *g, size_t n) {
+    int total_nodes = g->node_count + n;
+
     // Make sure we have room to store nodes.
-    if(g->node_count + n < g->node_cap)
+    if (total_nodes < g->node_cap)
         return;
 
-    int delta = (g->node_count + n) - g->node_cap;
-    // Add some additional extra space for future inserts.
-    delta += g->node_cap*2;
-
-    // Determine number of required NodeBlocks.
-    int new_blocks = GRAPH_NODE_COUNT_TO_BLOCK_COUNT(delta);
     int last_block = g->block_count - 1;
-    g->block_count += new_blocks;
-    g->nodes_blocks = realloc(g->nodes_blocks, sizeof(NodeBlock*) * g->block_count);
 
+    // Increase NodeBlock count by the smallest multiple required to contain all nodes
+    int increase_factor = (total_nodes / g->node_cap) + 1;
+    g->block_count *= increase_factor;
+
+    g->nodes_blocks = realloc(g->nodes_blocks, sizeof(NodeBlock*) * g->block_count);
     // Create and link blocks.
     for(int i = last_block; i < g->block_count-1; i++) {
         NodeBlock *block = g->nodes_blocks[i];


### PR DESCRIPTION
This is a pretty trivial modification, really, but I like it a bit better than the former delta approach. It has a bit less logical complexity, and it increases the number of blocks by an integer factor on each realloc (the other method would increase the number of blocks by `3x + (number of new blocks required)`)`.

The minimum realloc like this is `2x`, which I think is fine, but we can change that to `3x` to have a smaller change on the scaling factor while still growing by simpler factors.