### PR TITLE
Bulk insert progress meter

### DIFF
--- a/demo/bulk_insert/bulk_insert.py
+++ b/demo/bulk_insert/bulk_insert.py
@@ -53,12 +53,11 @@ class Descriptor:
 	self.entities_created = 0
 	self.pending_inserts = 0
 
-    def count_entities(self, csv_reader, reset_pos):
+    def count_entities(self, csv_reader):
 	# Count number of lines in file
 	self.total_entities = sum(1 for row in csv_reader)
-	# Reset iterator to start of entities
-	# (0 for relations, end of header row for nodes)
-	csv_reader.seek(reset_pos)
+	# Reset iterator to start of file
+	csv_reader.seek(0)
 
     def print_progress(self):
 	print '%.2f%% (%d / %d) of "%s" inserted.' % (float(self.entities_created) * 100 / self.total_entities,
@@ -142,7 +141,10 @@ def ProcessNodes(nodes_csv_files):
 			descriptor.attribute_count += header_len
 
 			# Count number of entities (line count - 1 for header row)
-			descriptor.count_entities(csvfile, header_len)
+			descriptor.count_entities(csvfile)
+
+			# Skip header row
+			reader.next()
 			print 'Inserting Label "%s" - %d nodes' % (label_name, descriptor.total_entities)
 
 			# 3 tokens for the descriptor name, insert count, and attribute count, and 1 for every attribute
@@ -200,7 +202,7 @@ def ProcessRelations(relations_csv_files):
 			descriptor = RelationDescriptor(relation_name)
 
 			# Count number of entities
-			descriptor.count_entities(csvfile, 0)
+			descriptor.count_entities(csvfile)
 			rels.descriptors.append(descriptor)
 			print 'Inserting Relation "%s" - %d edges.' % (relation_name, descriptor.total_entities)
 

--- a/demo/bulk_insert/bulk_insert.py
+++ b/demo/bulk_insert/bulk_insert.py
@@ -11,26 +11,22 @@ import click
 class Argument:
     def __init__(self, argtype):
 	self.argtype = argtype
-	self.pending_inserts = 0
-	self.type_count = 0
 	self.descriptors = []
 	self.entities_created = 0
 	self.queries_processed = 0
 
     def reset_tokens(self):
-	self.pending_inserts = 0
-        for descriptor in self.descriptors:
-	    descriptor.pending_inserts = 0
+	for descriptor in self.descriptors:
+	    descriptor.reset_tokens()
 
     def remove_descriptors(self, delete_count):
 	for descriptor in self.descriptors[:delete_count]:
 	    print 'Finished inserting "%s".' % descriptor.name
 	del self.descriptors[:delete_count]
-	self.type_count -= delete_count
 
     def unroll(self):
-	ret = [self.argtype, self.pending_inserts, self.type_count]
-        for descriptor in self.descriptors:
+	ret = [self.argtype, self.pending_inserts(), self.type_count()]
+	for descriptor in self.descriptors:
 	    # Don't include a descriptor unless we are inserting its entities.
 	    # This can occur if the addition of a descriptor and its first entity caused
 	    # the token count to exceed the max allowed
@@ -44,20 +40,30 @@ class Argument:
 	# ["NODES"/"RELATIONS", number of entities to insert, number of different entity types, list of type descriptors]
 	return 3 + sum(descriptor.token_count() for descriptor in self.descriptors)
 
-# Structure of a node insertion:
-# ["NODES", node count, label count, label_descriptors[0..n]]
+    def type_count(self):
+	return len(self.descriptors)
+
+    def pending_inserts(self):
+	return sum(desc.pending_inserts for desc in self.descriptors)
+
+# The Descriptor class holds the name and element counts for an individual relationship or node label.
+# After the contents of an Argument instance have been submitted to Redis in a GRAPH.BULK query,
+# the contents of each descriptor contained in the query are unrolled.
+# The `unroll` methods are unique to the data type.
 class Descriptor:
-    def __init__(self, name):
-	self.name = name
+    def __init__(self, csvfile):
+	# A Label or Relationship name is set by the CSV file name
+	self.name = os.path.splitext(os.path.basename(csvfile.name))[0]
 	self.total_entities = 0
 	self.entities_created = 0
 	self.pending_inserts = 0
+	self.reader = csv.reader(csvfile)
 
-    def count_entities(self, csv_reader):
+    def count_entities(self, csvfile):
 	# Count number of lines in file
-	self.total_entities = sum(1 for row in csv_reader)
+	self.total_entities = sum(1 for row in csvfile)
 	# Reset iterator to start of file
-	csv_reader.seek(0)
+	csvfile.seek(0)
 
     def print_progress(self):
 	print '%.2f%% (%d / %d) of "%s" inserted.' % (float(self.entities_created) * 100 / self.total_entities,
@@ -65,13 +71,25 @@ class Descriptor:
 		self.total_entities,
 		self.name)
 
-# Structure of a label descriptor:
-# [label name, node count, attribute count, attributes[0..n]]
+    def reset_tokens(self):
+	self.pending_inserts = 0
+
+# A LabelDescriptor consists of a name string, an entity count, and a series of
+# attributes (derived from the header row of the label CSV).
+# As a query string, a LabelDescriptor is printed in the format:
+# [label name, entity count, attribute count, attributes[0..n]]]
 class LabelDescriptor(Descriptor):
-    def __init__(self, name):
-	Descriptor.__init__(self, name)
-	self.attribute_count = 0
-	self.attributes = []
+    def __init__(self, csvfile):
+	Descriptor.__init__(self, csvfile)
+	# The first row of a label CSV contains its attributes
+	self.attributes = self.reader.next()
+	self.attribute_count = len(self.attributes)
+
+	# Count number of entities (line count - 1 for header row)
+	self.count_entities(csvfile)
+
+	# The CSV reader has been reset - skip the header row
+	self.reader.next()
 
     def token_count(self):
 	# Labels have a token for name, attribute count, pending insertion count, plus N tokens for the individual attributes.
@@ -80,10 +98,14 @@ class LabelDescriptor(Descriptor):
     def unroll(self):
 	return [self.name, self.pending_inserts, self.attribute_count] + self.attributes
 
-# TODO This seems kind of unnecessary, and should maybe be refactored
+# A RelationDescriptor consists of a name string and a relationship count.
+# As a query string, a RelationDescriptor is printed in the format:
+# [relation name, relation count]
 class RelationDescriptor(Descriptor):
-    def __init__(self, name):
-	Descriptor.__init__(self, name)
+    def __init__(self, csvfile):
+	Descriptor.__init__(self, csvfile)
+	# Count number of entities (line count)
+	self.count_entities(csvfile)
 
     def token_count(self):
 	# Relations have 2 tokens: name and pending insertion count.
@@ -119,67 +141,45 @@ def ProcessNodes(nodes_csv_files):
 	NODES = []		# List of nodes to be inserted
 	# TODO This will not be a valid assumption when the script gains support for insertion of unlabeled nodes
 	# Can use calls to the token_count methods, but that seems redundant
-	TOKEN_COUNT = 5 # "GRAPH.BULK [graphname] LABELS [entity_count] [type_count]"
+	TOKEN_COUNT = 5 # "GRAPH.BULK [graphname] LABELS [entity_count] [# of labels]"
 
 	depleted_labels = 0
 	# Process labeled nodes.
 	for node_csv_file in nodes_csv_files:
-		with open(node_csv_file, 'rb') as csvfile:
-			# Open the CSV file
-			reader = csv.reader(csvfile)
-			header_row = reader.next()
+	    with open(node_csv_file, 'rb') as csvfile:
+		descriptor = LabelDescriptor(csvfile)
+		print 'Inserting Label "%s" - %d nodes' % (descriptor.name, descriptor.total_entities)
 
-			# Make a new descriptor for this label
-			label_name = os.path.splitext(os.path.basename(node_csv_file))[0]
-			descriptor = LabelDescriptor(label_name)
-			# The first row of a label CSV contains its attributes
-			descriptor.attributes = header_row
+		# 3 tokens for the descriptor name, insert count, and attribute count, and 1 for every attribute
+		TOKEN_COUNT += 3 + descriptor.attribute_count
+		labels.descriptors.append(descriptor)
 
+		# Labeled nodes
+		for row in descriptor.reader:
+		    TOKEN_COUNT += len(row)
+		    if TOKEN_COUNT > max_tokens:
+			# max_tokens has been reached; submit all but the most recent node
+			QueryRedis(labels, NODES)
+			descriptor.entities_created += descriptor.pending_inserts
+			# Reset values post-query
+			labels.reset_tokens()
+			NODES = []
+			# If 1 or more CSVs have been depleted, remove their descriptors
+			if depleted_labels > 0:
+			    labels.remove_descriptors(depleted_labels)
+			    depleted_labels = 0
+			descriptor.print_progress()
+			# Following an insertion, TOKEN_COUNT is set to accommodate all labels
+			# and attributes, plus the individual tokens from the uninserted current row
+			TOKEN_COUNT = 2 + labels.token_count() + len(row)
+		    descriptor.pending_inserts += 1
+		    NODES += row
 
-			# Update counts
-			header_len = len(header_row)
-			descriptor.attribute_count += header_len
-
-			# Count number of entities (line count - 1 for header row)
-			descriptor.count_entities(csvfile)
-
-			# Skip header row
-			reader.next()
-			print 'Inserting Label "%s" - %d nodes' % (label_name, descriptor.total_entities)
-
-			# 3 tokens for the descriptor name, insert count, and attribute count, and 1 for every attribute
-			TOKEN_COUNT += 3 + header_len
-
-			# New label - process header row and add to `labels`
-			labels.descriptors.append(descriptor)
-			labels.type_count += 1
-
-			# Labeled nodes
-			for row in reader:
-				TOKEN_COUNT += len(row)
-				if TOKEN_COUNT > max_tokens:
-				    # max_tokens has been reached; submit all but the most recent node
-				    QueryRedis(labels, NODES)
-				    # Reset values post-query
-				    labels.reset_tokens()
-				    # Reset token count, including the one remaining row
-				    TOKEN_COUNT = 2 + labels.token_count() + len(row)
-				    NODES = []
-				    # If 1 or more CSVs have been depleted, remove their descriptors
-				    if depleted_labels > 0:
-					labels.remove_descriptors(depleted_labels)
-					depleted_labels = 0
-				    descriptor.entities_created = reader.line_num - 1
-				    descriptor.print_progress()
-				labels.pending_inserts += 1
-				descriptor.pending_inserts += 1
-				NODES += row
-
-			# A CSV has been fully processed; after the next insert its descriptor should be deleted
-			depleted_labels += 1
+		# A CSV has been fully processed; after the next insert its descriptor should be deleted
+		depleted_labels += 1
 	# Insert all remaining nodes
 	QueryRedis(labels, NODES)
-	# TODO should we manually delete labels and remaining descriptors here?
+	labels.remove_descriptors(depleted_labels)
 	print "%d Nodes created in %d queries." % (labels.entities_created, labels.queries_processed)
 
 # TODO This might be sufficiently similar to ProcessNodes to allow for just one function with different descriptors
@@ -193,49 +193,40 @@ def ProcessRelations(relations_csv_files):
 
 	# Process relations.
 	for relation_csv_file in relations_csv_files:
-		with open(relation_csv_file, 'rb') as csvfile:
-			# Open the CSV file
-			reader = csv.reader(csvfile)
+	    with open(relation_csv_file, 'rb') as csvfile:
+		descriptor = RelationDescriptor(csvfile)
+		print 'Inserting Relation "%s" - %d edges.' % (descriptor.name, descriptor.total_entities)
 
-			# Make a new descriptor for this relation
-			relation_name = os.path.splitext(os.path.basename(relation_csv_file))[0]
-			descriptor = RelationDescriptor(relation_name)
+		# Increase counts to accommodate two additional relation tokens (name and count)
+		TOKEN_COUNT += 2
+		rels.descriptors.append(descriptor)
 
-			# Count number of entities
-			descriptor.count_entities(csvfile)
-			rels.descriptors.append(descriptor)
-			print 'Inserting Relation "%s" - %d edges.' % (relation_name, descriptor.total_entities)
+		for row in descriptor.reader:
+		    TOKEN_COUNT += len(row)
+		    if TOKEN_COUNT > max_tokens:
+		    # max_tokens has been reached; submit all but the most recent entity
+			QueryRedis(rels, RELATIONS)
+			descriptor.entities_created += descriptor.pending_inserts
+			# After the query, subtract submitted counts from rels
+			rels.reset_tokens()
+			RELATIONS = []
+			# If 1 or more CSVs have been depleted, remove their descriptors
+			if depleted_relations > 0:
+				rels.remove_descriptors(depleted_relations)
+				depleted_relations = 0
+			descriptor.print_progress()
+			# Following an insertion, TOKEN_COUNT is set to accommodate all relations
+			# plus the individual tokens from the uninserted current row
+			TOKEN_COUNT = 2 + rels.token_count() + len(row)
+		    descriptor.pending_inserts += 1
+		    RELATIONS += row
 
-			# Increase counts to accommodate two additional relation tokens (name and count)
-			TOKEN_COUNT += 2
-			rels.type_count += 1
-
-			for row in reader:
-				TOKEN_COUNT += len(row)
-				if TOKEN_COUNT > max_tokens:
-				    # max_tokens has been reached; submit all but the most recent entity
-				    QueryRedis(rels, RELATIONS)
-				    # After the query, subtract submitted counts from rels
-				    rels.reset_tokens()
-				    # Reset token count, including the one remaining row
-				    TOKEN_COUNT = 2 + rels.token_count() + len(row)
-				    RELATIONS = []
-				    # If 1 or more CSVs have been depleted, remove their descriptors
-				    if depleted_relations > 0:
-					rels.remove_descriptors(depleted_relations)
-					depleted_relations = 0
-				    # If a descriptor has been partially inserted, print its progress
-				    descriptor.entities_created = reader.line_num
-				    descriptor.print_progress()
-				rels.pending_inserts += 1
-				descriptor.pending_inserts += 1
-				RELATIONS += row
-
-			# A CSV has been fully processed; after the next insert its descriptor should be deleted
-			depleted_relations += 1
+		# A CSV has been fully processed; after the next insert its descriptor should be deleted
+		depleted_relations += 1
 
 	# Insert all remaining relations
 	QueryRedis(rels, RELATIONS)
+	rels.remove_descriptors(depleted_relations)
 	print "%d Relations created in %d queries." % (rels.entities_created, rels.queries_processed)
 
 def help():

--- a/src/bulk_insert.c
+++ b/src/bulk_insert.c
@@ -272,7 +272,8 @@ RedisModuleString** _Bulk_Insert_Insert_Edges(RedisModuleCtx *ctx, RedisModuleSt
     }
 
     long long total_labeled_edges = 0;
-    GrB_Index connections[relations_count*3];       // Triplet (src,dest,relation)
+    // As we can have over 500k relations, this is safer as a heap allocation.
+    GrB_Index *connections = malloc(relations_count * 3 * sizeof(GrB_Index));       // Triplet (src,dest,relation)
     LabelRelation labelRelations[label_count + 1];  // Extra one for unlabeled relations.
 
     if(label_count > 0) {
@@ -331,6 +332,9 @@ RedisModuleString** _Bulk_Insert_Insert_Edges(RedisModuleCtx *ctx, RedisModuleSt
     }
 
     Graph_ConnectNodes(g, relations_count*3, connections);
+
+    free(connections);
+
     return argv;
 }
 

--- a/tests/flow/test_bulk_insertion.py
+++ b/tests/flow/test_bulk_insertion.py
@@ -20,6 +20,7 @@ def redis():
 class GraphBulkInsertFlowTest(FlowTestsBase):
 	@classmethod
 	def setUpClass(cls):
+		print "GraphBulkInsertFlowTest"
 		global redis_con
 		global port
 


### PR DESCRIPTION
This PR corrects the token count logic on large inserts of relations, so that the largest insert buffer possible should always be created without causing Redis to block the query.

It additionally adds some console logging to give the user some knowledge of how far along the process is. The logging is accurate, but a bit rudimentary - every time a buffer is passed to Redis, it prints the entity inserted vs. total counts for the current CSV, as well as the percent completion of that inserted.

This has the potential to get pretty spammy on really large CSVs, and if many different labels and/or relationships are being inserted, it doesn't give much context on how far along the overall creation is.

In order to give overall creation context, we would need to get the line count of all input files before doing any processing, which is an option, but it seems kind of ugly to me.

For making sure the console doesn't get spammed, we can choose to only print once certain thresholds have been met, which is easy enough, but I imagine that Python also has some nice modules for creating progress bars or similar. Any preferences?  