### PR TITLE
result-set record used to be a single comma delimited string

### DIFF
--- a/demo/imdb/requirements.txt
+++ b/demo/imdb/requirements.txt
@@ -1,2 +1,2 @@
 redis==2.10.5
-redisgraph
+redisgraph>=1.4

--- a/demo/social/requirements.txt
+++ b/demo/social/requirements.txt
@@ -1,2 +1,2 @@
 redis==2.10.5
-redisgraph
+redisgraph>=1.4

--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,3 +1,3 @@
 redis==2.10.5
-redisgraph
+redisgraph>=1.4
 rmtest


### PR DESCRIPTION
This breaks once a value contains comma, this commit changes result-set structure to return records and the header row as individual arrays.