### PR TITLE
Implement quicksort for ORDER clauses

### DIFF
--- a/src/rmutil/vector.c
+++ b/src/rmutil/vector.c
@@ -32,6 +32,10 @@ inline int Vector_Pop(Vector *v, void *ptr) {
   return 0;
 }
 
+void* Vector_Data(const Vector *v) {
+  return (void*)v->data;
+}
+
 inline int __vector_PutPtr(Vector *v, size_t pos, void *elem) {
   // resize if pos is out of bounds
   if (pos >= v->cap) {

--- a/src/rmutil/vector.h
+++ b/src/rmutil/vector.h
@@ -40,6 +40,9 @@ int Vector_Get(const Vector *v, size_t pos, void *ptr);
 /* Get the element at the end of the vector, decreasing the size by one */
 int Vector_Pop(Vector *v, void *ptr);
 
+/* Retrieve the data array from a vector */
+void* Vector_Data(const Vector *v);
+
 //#define Vector_Getx(v, pos, ptr) pos < v->cap ? 1 : 0; *ptr =
 //*(typeof(ptr))(v->data + v->elemSize*pos)
 
@@ -71,7 +74,5 @@ void Vector_Clear(Vector *v);
 /* free the vector and the underlying data. Does not release its elements if
  * they are pointers*/
 void Vector_Free(Vector *v);
-
-int __vecotr_PutPtr(Vector *v, size_t pos, void *elem);
 
 #endif

--- a/src/value.c
+++ b/src/value.c
@@ -412,12 +412,34 @@ size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *b
 }
 
 int SIValue_Compare(SIValue a, SIValue b) {
-  // TODO: Use SI_NUMERIC.
-  if(a.type == T_DOUBLE) {
-    return a.doubleval - b.doubleval;
-  } else {
-    return strcasecmp(a.stringval, b.stringval);
+  // Types are identical
+  if (a.type == b.type) {
+    if (a.type == T_DOUBLE) {
+      /* TODO - inf, -inf, and  NaN do not behave canonically in this routine,
+       * though they do not break anything. Low-priority bug. */
+      return a.doubleval - b.doubleval;
+    } else if (a.type == T_STRING) {
+      return strcasecmp(a.stringval, b.stringval);
+    } else {
+      // TODO matching unhandled types - revisit this when introducing other numerics
+      return 0;
+    }
   }
+
+  // Types differ
+  /* Cypher specifies the following ascending order of disjoint types:
+   * - String
+   * - Number
+   * - NULL
+   */
+  if (a.type == T_STRING) {
+    return -1;
+  }
+  if (b.type == T_STRING) {
+    return 1;
+  }
+
+  return a.type - b.type;
 }
 
 void SIValue_Print(FILE *outstream, SIValue *v) {

--- a/src/value.c
+++ b/src/value.c
@@ -439,7 +439,7 @@ int SIValue_Compare(SIValue a, SIValue b) {
     return 1;
   }
 
-  return a.type - b.type;
+  return b.type - a.type;
 }
 
 void SIValue_Print(FILE *outstream, SIValue *v) {

--- a/src/value.h
+++ b/src/value.h
@@ -15,7 +15,11 @@
 typedef char *SIId;
 
 /* Type defines the supported types by the indexing system. The types are powers
- * of 2 so they can be used in bitmasks of matching types */
+ * of 2 so they can be used in bitmasks of matching types.
+ *
+ * The order of these values is significant, as the delta between values of
+ * differing types is used to maintain the Cypher-defined global sort order
+ * in the SIValue_Compare routine. */
 typedef enum {
   T_NULL = 0,
   T_STRING = 0x001,


### PR DESCRIPTION
Queries that have an ORDER BY clause and no limit will use a quicksort algorithm to sort result set records.

The `SIValue_Compare` function has better handling of disjoint types, resolving issue #86.