### PR TITLE
Set node ID in iterator for AllNodeScan

### DIFF
--- a/src/graph/node_iterator.c
+++ b/src/graph/node_iterator.c
@@ -36,6 +36,9 @@ Node *NodeIterator_Next(NodeIterator *iter) {
     NodeBlock *block = iter->_current_block;
     Node *n = &block->nodes[iter->_block_pos];
 
+    // Update node ID
+    n->id = iter->_current_pos;
+
     // Advance to next position.
     iter->_block_pos += iter->_step;
     iter->_current_pos += iter->_step;


### PR DESCRIPTION
In a label scan, we explicitly set the ID for nodes in the `Graph_GetNode` call of the consume stage. This PR makes AllNodeScan ops also set the ID. Before this change, ID might be returned unset if no prior operation had modified it:

```
127.0.0.1:6379> GRAPH.QUERY contrived "MATCH (a) RETURN a.name, ID(a) LIMIT 3"
1) 1) 1) "a.name"
      2) "ID(a)"
   2) 1) "Roi Lipman"
      2) "0"
   3) 1) "Alon Fital"
      2) "0"
   4) 1) "Ailon Velger"
      2) "0"
2) 1) "Query internal execution time: 0.417810 milliseconds"
```