### PR TITLE
Use value for firstExpLabeled

### DIFF
--- a/src/execution_plan/optimizations/traverse_order.c
+++ b/src/execution_plan/optimizations/traverse_order.c
@@ -65,7 +65,7 @@ TRAVERSE_ORDER determineTraverseOrder(const QueryGraph *qg,
      * do not have a filter applied to them. In that case
      * prefer the expression which have a label specified
      * for either its source or destination node. */
-    if(lastExpLabeled) order = TRAVERSE_ORDER_LAST;
+    if(!firstExpLabeled && lastExpLabeled) order = TRAVERSE_ORDER_LAST;
 
 cleanup:
     for(int i = 0; i < aliasesCount; i++) {


### PR DESCRIPTION
This is a minor tweak that we discussed before - `firstExpLabeled` was set but not used, so we were defaulting to TRAVERSE_ORDER_LAST when both the first and last operand were label scans.