### PR TITLE
Strict return validations

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -163,10 +163,11 @@ void _MGraph_Query(void *args) {
     AST_Query* ast = qctx->ast;
     const char *graph_name = RedisModule_StringPtrLen(qctx->graphName, NULL);
 
-    ModifyAST(ctx, ast, graph_name);
-
     char *reason;
-    if (AST_Validate(ast, &reason) != AST_VALID) {
+    AST_Validation res = ModifyAST(ctx, ast, graph_name, &reason);
+
+    // If ModifyAST failed or AST_Validate fails, clean up and return an error
+    if ((res != AST_VALID) || AST_Validate(ast, &reason) != AST_VALID) {
         RedisModule_ReplyWithError(ctx, reason);
         free(reason);
         goto cleanup;
@@ -398,10 +399,11 @@ int MGraph_Explain(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
     }
 
-    ModifyAST(ctx, ast, graph_name);
-
     char *reason;
-    if (AST_Validate(ast, &reason) != AST_VALID) {
+    AST_Validation res = ModifyAST(ctx, ast, graph_name, &reason);
+
+    // If ModifyAST failed or AST_Validate fails, clean up and return an error
+    if ((res != AST_VALID) || AST_Validate(ast, &reason) != AST_VALID) {
         RedisModule_ReplyWithError(ctx, reason);
         free(reason);
         return REDISMODULE_OK;

--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -113,6 +113,10 @@ AST_Validation _Validate_MATCH_Clause(const AST_Query *ast, char **reason) {
     if(entity->t != N_LINK) continue;
 
     char *alias = entity->alias;
+    /* The query is validated before and after aliasing anonymous entities,
+     * so alias may be NULL at this time. */
+    if (!alias) continue;
+
     int new = TrieMap_Add(edgeAliases, alias, strlen(alias), NULL, TrieMap_DONT_CARE_REPLACE);
     if(!new) {
       asprintf(reason, "Cannot use the same relationship variable '%s' for multiple patterns.", alias);

--- a/src/parser/clauses/match.c
+++ b/src/parser/clauses/match.c
@@ -34,6 +34,7 @@ void MatchClause_ReferredNodes(const AST_MatchNode *matchNode, TrieMap *referred
 	for(int i = 0; i < entityCount; i++) {
 		AST_GraphEntity *entity;
 		Vector_Get(matchNode->_mergedPatterns, i, &entity);
+		if (!entity->alias) continue;
 		TrieMap_Add(referred_nodes, entity->alias, strlen(entity->alias), NULL, NULL);
 	}
 }

--- a/src/parser/clauses/return.c
+++ b/src/parser/clauses/return.c
@@ -120,7 +120,7 @@ void Free_AST_ReturnElementNode(AST_ReturnElementNode *returnElementNode) {
 }
 
 void Free_AST_ReturnNode(AST_ReturnNode *returnNode) {
-    if(! returnNode) return;
+	if (!returnNode) return;
 	for (int i = 0; i < Vector_Size(returnNode->returnElements); i++) {
 		AST_ReturnElementNode *node;
 		Vector_Get(returnNode->returnElements, i, &node);

--- a/src/query_executor.c
+++ b/src/query_executor.c
@@ -72,16 +72,8 @@ void ReturnClause_ExpandCollapsedNodes(RedisModuleCtx *ctx, AST_Query *ast, cons
              * Find collapsed entity's label. */
             AST_GraphEntity *collapsed_entity = MatchClause_GetEntity(ast->matchNode, exp->operand.variadic.alias);
 
-            /* Invalid query, return clause refers to non-existent entity. */
-            if(collapsed_entity == NULL) {
-                /* Free the replacement elements that have been built so far. */
-                for (int j = 0; i < Vector_Size(expandReturnElements); j ++) {
-                    Vector_Get(expandReturnElements, i, &ret_elem);
-                    Free_AST_ReturnElementNode(ret_elem);
-                }
-                Vector_Free(expandReturnElements);
-                return;
-            }
+            /* We have already validated the query at this point, so all entity lookups should succeed. */
+            assert(collapsed_entity);
 
             /* Find label's properties. */
             LabelStoreType store_type = (collapsed_entity->t == N_ENTITY) ? STORE_NODE : STORE_EDGE;
@@ -123,9 +115,6 @@ void ReturnClause_ExpandCollapsedNodes(RedisModuleCtx *ctx, AST_Query *ast, cons
 
             /* Discard collapsed return element. */
             Free_AST_ReturnElementNode(ret_elem);
-            /* NULL out freed elements so we can properly free the return clause
-             * if we return from this function early. */
-            Vector_Put(ast->returnNode->returnElements, i, NULL);
         } else {
             Vector_Push(expandReturnElements, ret_elem);
         }

--- a/src/query_executor.h
+++ b/src/query_executor.h
@@ -31,6 +31,6 @@ void Build_None_Aggregated_Arithmetic_Expressions(AST_ReturnNode *return_node, A
 AST_Query* ParseQuery(const char *query, size_t qLen, char **errMsg);
 
 /* Performs a number of adjustments to given AST. */
-void ModifyAST(RedisModuleCtx *ctx, AST_Query *ast, const char *graph_name);
+AST_Validation ModifyAST(RedisModuleCtx *ctx, AST_Query *ast, const char *graph_name, char **reason);
 
 #endif

--- a/src/query_executor.h
+++ b/src/query_executor.h
@@ -31,6 +31,6 @@ void Build_None_Aggregated_Arithmetic_Expressions(AST_ReturnNode *return_node, A
 AST_Query* ParseQuery(const char *query, size_t qLen, char **errMsg);
 
 /* Performs a number of adjustments to given AST. */
-AST_Validation ModifyAST(RedisModuleCtx *ctx, AST_Query *ast, const char *graph_name, char **reason);
+void ModifyAST(RedisModuleCtx *ctx, AST_Query *ast, const char *graph_name);
 
 #endif


### PR DESCRIPTION
This PR resolves issue #110
 
The `ModifyAST` function (which for many queries must precede `AST_Validate`) can now construct and return user-facing error messages.