### PR TITLE
Arithmetic function filters

### DIFF
--- a/demo/imdb/imdb_queries.py
+++ b/demo/imdb/imdb_queries.py
@@ -175,6 +175,18 @@ actors_over_85_index_scan = QueryInfo(
         ['Vincent Price', '107.000000']]
 )
 
+eighties_movies_index_scan = QueryInfo(
+    query="""MATCH (m:movie)
+             WHERE 1980 <= m.year
+             AND m.year < 1990
+             RETURN m.title, m.year
+             ORDER BY m.year""",
+    description='Multiple filters on indexed property?',
+    max_run_time_ms=1.5,
+    expected_result=[['The Evil Dead', '1981.000000'],
+                     ['Vincent', '1982.000000']]
+)
+
 find_titles_starting_with_american_query = QueryInfo(
     query="""MATCH (m:movie)
              WHERE LEFT(m.title, 8) = 'American'
@@ -198,5 +210,6 @@ queries_info = [
     how_many_movies_cameron_diaz_played_query,
     find_ten_oldest_actors_query,
     actors_over_85_index_scan,
+    eighties_movies_index_scan,
     find_titles_starting_with_american_query
 ]

--- a/demo/imdb/imdb_queries.py
+++ b/demo/imdb/imdb_queries.py
@@ -175,6 +175,17 @@ actors_over_85_index_scan = QueryInfo(
         ['Vincent Price', '107.000000']]
 )
 
+find_titles_starting_with_american_query = QueryInfo(
+    query="""MATCH (m:movie)
+             WHERE LEFT(m.title, 8) = 'American'
+             RETURN m.title 
+             ORDER BY m.title""",
+    description='Movies starting with "American"?',
+    max_run_time_ms=4,
+    expected_result=[['American Honey'],
+                     ['American Pastoral'],
+                     ['American Sniper']]
+)
 queries_info = [
     actors_played_with_nicolas_cage_query,
     find_three_actors_played_with_nicolas_cage_query,
@@ -186,5 +197,6 @@ queries_info = [
     sum_and_average_age_of_straight_outta_compton_cast_query,
     how_many_movies_cameron_diaz_played_query,
     find_ten_oldest_actors_query,
-    actors_over_85_index_scan
+    actors_over_85_index_scan,
+    find_titles_starting_with_american_query
 ]

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -121,7 +121,7 @@ AR_ExpNode* AR_EXP_NewOpNode(char *func_name, int child_count) {
     node->op.child_count = child_count;
     node->op.children = (AR_ExpNode **)malloc(child_count * sizeof(AR_ExpNode*));
 
-    /* Determin function type. */
+    /* Determine function type. */
     AR_Func func = AR_GetFunc(func_name);
     if(func != NULL) {
         node->op.f = func;

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -17,6 +17,15 @@
 /* Arithmetic function repository. */
 static TrieMap *__aeRegisteredFuncs = NULL;
 
+/* Utility functions */
+int AR_EXP_IsNodeVariadicOperand(AR_ExpNode *exp) {
+    return (exp->type == AR_EXP_OPERAND) && (exp->operand.type == AR_EXP_VARIADIC);
+}
+
+int AR_EXP_IsNodeConstantOperand(AR_ExpNode *exp) {
+    return (exp->type == AR_EXP_OPERAND) && (exp->operand.type == AR_EXP_CONSTANT);
+}
+
 SIValue AR_EXP_Evaluate(const AR_ExpNode *root) {
 
     SIValue result;

--- a/src/arithmetic/arithmetic_expression.h
+++ b/src/arithmetic/arithmetic_expression.h
@@ -128,6 +128,12 @@ AR_ExpNode* AR_EXP_NewVariableOperandNode(GraphEntity **entity, const char *enti
 AR_ExpNode* AR_EXP_NewOpNode(char *func_name, int child_count);
 
 /* Utility functions */
+/* Link variadics in expression tree to their corresponding QueryGraph entities. */
+void AR_EXP_BindVariadics(AR_ExpNode *root, const QueryGraph *qg);
+/* Traverse an expression tree and add all graph entity aliases
+ * (from variadics) to a triemap. */
+void AR_EXP_CollectAliases(AR_ExpNode *root, TrieMap *aliases);
+
 /* Search for an aggregation node within the expression tree.
  * Return 1 and sets agg_node to the aggregation node if exists,
  * Please note an expression tree can only contain a single aggregation node. */

--- a/src/arithmetic/arithmetic_expression.h
+++ b/src/arithmetic/arithmetic_expression.h
@@ -117,8 +117,8 @@ struct AR_ExpNode {
 
 typedef struct AR_ExpNode AR_ExpNode;
 
-int AR_EXP_IsNodeVariadicOperand(AR_ExpNode *exp);
-int AR_EXP_IsNodeConstantOperand(AR_ExpNode *exp);
+/* Return AR_OperandNodeType for operands and -1 for operations. */
+int AR_EXP_GetOperandType(AR_ExpNode *exp);
 
 /* Evaluate arithmetic expression tree. */
 SIValue AR_EXP_Evaluate(const AR_ExpNode *root);
@@ -131,8 +131,6 @@ AR_ExpNode* AR_EXP_NewVariableOperandNode(GraphEntity **entity, const char *enti
 AR_ExpNode* AR_EXP_NewOpNode(char *func_name, int child_count);
 
 /* Utility functions */
-/* Link variadics in expression tree to their corresponding QueryGraph entities. */
-void AR_EXP_BindVariadics(AR_ExpNode *root, const QueryGraph *qg);
 /* Traverse an expression tree and add all graph entity aliases
  * (from variadics) to a triemap. */
 void AR_EXP_CollectAliases(AR_ExpNode *root, TrieMap *aliases);

--- a/src/arithmetic/arithmetic_expression.h
+++ b/src/arithmetic/arithmetic_expression.h
@@ -117,6 +117,9 @@ struct AR_ExpNode {
 
 typedef struct AR_ExpNode AR_ExpNode;
 
+int AR_EXP_IsNodeVariadicOperand(AR_ExpNode *exp);
+int AR_EXP_IsNodeConstantOperand(AR_ExpNode *exp);
+
 /* Evaluate arithmetic expression tree. */
 SIValue AR_EXP_Evaluate(const AR_ExpNode *root);
 void AR_EXP_Aggregate(const AR_ExpNode *root);

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -280,15 +280,19 @@ ExecutionPlan* NewExecutionPlan(RedisModuleCtx *ctx, Graph *g,
     _Determine_Graph_Size(ast, &node_count, &edge_count);
     QueryGraph *q = NewQueryGraph_WithCapacity(node_count, edge_count);
     execution_plan->graph = q;
+
+    // Build the query graph in advance, as it will be used to construct the filter tree
+    if(ast->matchNode) {
+        BuildQueryGraph(ctx, g, graph_name, q, ast->matchNode->_mergedPatterns);
+    }
+
     FT_FilterNode *filter_tree = NULL;
     if(ast->whereNode != NULL) {
-        filter_tree = BuildFiltersTree(ast->whereNode->filters);
+        filter_tree = BuildFiltersTree(ast->whereNode->filters, q);
         execution_plan->filter_tree = filter_tree;
     }
 
     if(ast->matchNode) {
-        BuildQueryGraph(ctx, g, graph_name, q, ast->matchNode->_mergedPatterns);
-
         // For every pattern in match clause.
         size_t patternCount = Vector_Size(ast->matchNode->patterns);
         

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -433,7 +433,6 @@ ExecutionPlan* NewExecutionPlan(RedisModuleCtx *ctx, Graph *g,
     }
 
     if(ast->whereNode != NULL) {
-        FilterTree_bindEntities(execution_plan->filter_tree, execution_plan->graph);
         Vector *sub_trees = FilterTree_SubTrees(execution_plan->filter_tree);
 
         /* For each filter tree find the earliest position along the execution 

--- a/src/execution_plan/optimizations/utilize_indices.c
+++ b/src/execution_plan/optimizations/utilize_indices.c
@@ -12,9 +12,11 @@ void _locateScanFilters(NodeByLabelScan *scanOp, Vector *filterOps) {
     /* filterTree will either be a predicate or a tree with an OR root.
      * We'll store ops on const predicate filters, and can otherwise safely ignore them -
      * no filter tree in this sequence can invalidate another. */
+    /*
     if (IsNodeConstantPredicate(filterTree)) {
       Vector_Push(filterOps, current);
     }
+    */
 
     // Advance to the next operation.
     current = current->parent;
@@ -44,7 +46,7 @@ void utilizeIndices(RedisModuleCtx *ctx, const char *graph_name, ExecutionPlan *
   NodeByLabelScan *scanOp;
   Vector *filterOps = NewVector(OpBase*, 0);
   FT_FilterNode *ft;
-  char *label;
+  // char *label;
 
   IndexIter *iter = NULL;
   Index *idx = NULL;
@@ -52,7 +54,7 @@ void utilizeIndices(RedisModuleCtx *ctx, const char *graph_name, ExecutionPlan *
   while (Vector_Pop(scanOps, &scanOp)) {
     /* Get the label string for the scan target.
      * The label will be used to retrieve the index. */
-    label = (*scanOp->node)->label;
+    // label = (*scanOp->node)->label;
     Vector_Clear(filterOps);
     _locateScanFilters(scanOp, filterOps);
 
@@ -73,6 +75,7 @@ void utilizeIndices(RedisModuleCtx *ctx, const char *graph_name, ExecutionPlan *
       ft = ((Filter *)opFilter)->filterTree;
 
       // If we've already selected an index on a different property, continue
+      /*
       if (idx && strcmp(idx->property, ft->pred.Lop.property)) continue;
 
       // Try to retrieve an index if one has not been selected yet
@@ -81,6 +84,7 @@ void utilizeIndices(RedisModuleCtx *ctx, const char *graph_name, ExecutionPlan *
         if (!idx) continue;
         iter = IndexIter_Create(idx, ft->pred.constVal.type);
       }
+      */
 
       // Tighten the iterator range if possible
       if (IndexIter_ApplyBound(iter, &ft->pred)) {

--- a/src/execution_plan/optimizations/utilize_indices.c
+++ b/src/execution_plan/optimizations/utilize_indices.c
@@ -71,8 +71,10 @@ void utilizeIndices(RedisModuleCtx *ctx, const char *graph_name, ExecutionPlan *
       OpBase *opFilter;
       Vector_Get(filterOps, i, &opFilter);
       ft = ((Filter *)opFilter)->filterTree;
-      // TODO for the moment, only use filters with left-hand node-property pairs
-      // and right-hand values. This should be pretty easy to improve upon.
+      /* We'll only employ indices when we have filters of the form:
+       * node.property [rel] constant
+       * If we are not comparing against a constant, then we cannot pre-define useful bounds
+       * for the index iterator, which diminishes their utility. */
       if (!AR_EXP_IsNodeVariadicOperand(ft->pred.lhs)) continue;
       if (!AR_EXP_IsNodeConstantOperand(ft->pred.rhs)) continue;
 

--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -126,10 +126,10 @@ int _applyPredicateFilters(const FT_FilterNode* root) {
     /* A op B
      * Evaluate the left and right sides of the predicate to obtain
      * comparable SIValues. */
-     SIValue lhs = AR_EXP_Evaluate(root->pred.lhs);
-     SIValue rhs = AR_EXP_Evaluate(root->pred.rhs);
+    SIValue lhs = AR_EXP_Evaluate(root->pred.lhs);
+    SIValue rhs = AR_EXP_Evaluate(root->pred.rhs);
 
-     return _applyFilter(&lhs, &rhs, root->pred.op);
+    return _applyFilter(&lhs, &rhs, root->pred.op);
 }
 
 int FilterTree_applyFilters(const FT_FilterNode* root) {
@@ -155,7 +155,6 @@ int FilterTree_applyFilters(const FT_FilterNode* root) {
 }
 
 void FilterTree_bindEntities(FT_FilterNode* root, const QueryGraph *g) {
-    char *alias;
     switch(root->t) {
         case FT_N_COND:
             FilterTree_bindEntities(root->cond.left, g);
@@ -187,7 +186,7 @@ void _FilterTree_CollectAliases(const FT_FilterNode *root, TrieMap *aliases) {
             /* Traverse left and right-hand expressions, adding all encountered aliases
              * to the triemap.
              * We'll typically encounter 0 or 1 aliases in each expression,
-             * but there are multi-argument exceptions (like concat). */
+             * but there are multi-argument exceptions. */
             AR_EXP_CollectAliases(root->pred.lhs, aliases);
             AR_EXP_CollectAliases(root->pred.rhs, aliases);
 

--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -159,13 +159,6 @@ int FilterTree_applyFilters(const FT_FilterNode* root) {
     return pass;
 }
 
-void FilterTree_bindEntities(FT_FilterNode* root, const QueryGraph *g) {
-    if (root->t == FT_N_COND) {
-        FilterTree_bindEntities(root->cond.left, g);
-        FilterTree_bindEntities(root->cond.right, g);
-    }
-}
-
 void _FilterTree_CollectAliases(const FT_FilterNode *root, TrieMap *aliases) {
     if(root == NULL) return;
 

--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -217,6 +217,7 @@ Vector *FilterTree_CollectAliases(const FT_FilterNode *root) {
         Vector_Push(aliases, alias);
     }
 
+    TrieMapIterator_Free(it);
     TrieMap_Free(t, NULL);
     return aliases;
 }

--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -15,7 +15,7 @@
 FT_FilterNode* LeftChild(const FT_FilterNode *node) { return node->cond.left; }
 FT_FilterNode* RightChild(const FT_FilterNode *node) { return node->cond.right; }
 
-int static inline IsNodePredicate(const FT_FilterNode *node) {
+int IsNodePredicate(const FT_FilterNode *node) {
     return node->t == FT_N_PRED;
 }
 

--- a/src/filter_tree/filter_tree.h
+++ b/src/filter_tree/filter_tree.h
@@ -12,6 +12,7 @@
 #include "../parser/ast.h"
 #include "../graph/query_graph.h"
 #include "../redismodule.h"
+#include "../arithmetic/arithmetic_expression.h"
 
 #define FILTER_FAIL 0
 #define FILTER_PASS 1
@@ -25,16 +26,20 @@ typedef enum {
 typedef enum {
 	FT_N_CONSTANT,
 	FT_N_VARYING,
+  FT_N_FUNCTION,
 } FT_CompareValueType;
 
 struct FT_FilterNode;
 
 typedef struct {
-	struct {			    /* Left side of predicate. */
-		char* alias;		/* Element in question alias. */
-		char* property;		/* Element's property to check. */
-		GraphEntity **e;	/* Left side entity. */
-	} Lop;
+  union {
+    AR_ExpNode *func;
+    struct {			    /* Left side of predicate. */
+      char* alias;		/* Element in question alias. */
+      char* property;		/* Element's property to check. */
+      GraphEntity **e;	/* Left side entity. */
+    } Lop;
+  };
 	int op;					/* Operation (<, <=, =, =>, >, !). */
 	union {					/* Right side of predicate. */
 		SIValue constVal;	/* Value to compare against. */
@@ -44,8 +49,8 @@ typedef struct {
 			GraphEntity **e;	/* Right side entity. */
 		} Rop;
 	};
-	FT_CompareValueType t; 	/* Compared value type, constant/node. */
-	CmpFunc cf;				/* Compare function, determins relation between val and element property. */
+	FT_CompareValueType t; 	/* Compared value type, constant/node/function. */
+	CmpFunc cf;				/* Compare function, determines relation between val and element property. */
 } FT_PredicateNode;
 
 typedef struct {
@@ -60,7 +65,7 @@ struct FT_FilterNode {
     FT_PredicateNode pred;
     FT_ConditionNode cond;
   };
-  FT_FilterNodeType t;	/* Determins actual type of this node. */
+  FT_FilterNodeType t;	/* Determines actual type of this node. */
 };
 
 typedef struct FT_FilterNode FT_FilterNode;

--- a/src/filter_tree/filter_tree.h
+++ b/src/filter_tree/filter_tree.h
@@ -52,6 +52,8 @@ typedef struct FT_FilterNode FT_FilterNode;
  * This is done to speed up the filtering process. */
 FT_FilterNode* BuildFiltersTree(const AST_FilterNode *root);
 
+int IsNodePredicate(const FT_FilterNode *node);
+
 FT_FilterNode* CreateCondFilterNode(int op);
 
 FT_FilterNode *AppendLeftChild(FT_FilterNode *root, FT_FilterNode *child);

--- a/src/filter_tree/filter_tree.h
+++ b/src/filter_tree/filter_tree.h
@@ -50,7 +50,7 @@ typedef struct FT_FilterNode FT_FilterNode;
 
 /* Given AST's WHERE subtree constructs a filter tree
  * This is done to speed up the filtering process. */
-FT_FilterNode* BuildFiltersTree(const AST_FilterNode *root);
+FT_FilterNode* BuildFiltersTree(const AST_FilterNode *root, const QueryGraph *qg);
 
 int IsNodePredicate(const FT_FilterNode *node);
 

--- a/src/filter_tree/filter_tree.h
+++ b/src/filter_tree/filter_tree.h
@@ -62,9 +62,6 @@ FT_FilterNode *AppendRightChild(FT_FilterNode *root, FT_FilterNode *child);
 /* Runs val through the filter tree. */
 int FilterTree_applyFilters(const FT_FilterNode* root);
 
-/* Binds filtered entities to query graph. */
-void FilterTree_bindEntities(FT_FilterNode* root, const QueryGraph *g);
-
 /* Extract every alias mentioned in the tree
  * without duplications. */
 Vector *FilterTree_CollectAliases(const FT_FilterNode *root);

--- a/src/filter_tree/filter_tree.h
+++ b/src/filter_tree/filter_tree.h
@@ -23,34 +23,12 @@ typedef enum {
   FT_N_COND,
 } FT_FilterNodeType;
 
-typedef enum {
-	FT_N_CONSTANT,
-	FT_N_VARYING,
-  FT_N_FUNCTION,
-} FT_CompareValueType;
-
 struct FT_FilterNode;
 
 typedef struct {
-  union {
-    AR_ExpNode *func;
-    struct {			    /* Left side of predicate. */
-      char* alias;		/* Element in question alias. */
-      char* property;		/* Element's property to check. */
-      GraphEntity **e;	/* Left side entity. */
-    } Lop;
-  };
+	AR_ExpNode *lhs;
+	AR_ExpNode *rhs;
 	int op;					/* Operation (<, <=, =, =>, >, !). */
-	union {					/* Right side of predicate. */
-		SIValue constVal;	/* Value to compare against. */
-		struct {
-			char* alias;		/* Element in question alias. */
-			char* property;		/* Element's property to check. */
-			GraphEntity **e;	/* Right side entity. */
-		} Rop;
-	};
-	FT_CompareValueType t; 	/* Compared value type, constant/node/function. */
-	CmpFunc cf;				/* Compare function, determines relation between val and element property. */
 } FT_PredicateNode;
 
 typedef struct {
@@ -74,8 +52,6 @@ typedef struct FT_FilterNode FT_FilterNode;
  * This is done to speed up the filtering process. */
 FT_FilterNode* BuildFiltersTree(const AST_FilterNode *root);
 
-FT_FilterNode* CreateVaryingFilterNode(const char *LAlias, const char *LProperty, const char *RAlias, const char *RProperty, int op);
-FT_FilterNode* CreateConstFilterNode(const char *alias, const char *property, int op, SIValue val);
 FT_FilterNode* CreateCondFilterNode(int op);
 
 FT_FilterNode *AppendLeftChild(FT_FilterNode *root, FT_FilterNode *child);
@@ -101,7 +77,5 @@ void FilterTree_Print(const FT_FilterNode *root);
 Vector* FilterTree_SubTrees(const FT_FilterNode *root);
 
 void FilterTree_Free(FT_FilterNode *root);
-
-int IsNodeConstantPredicate(const FT_FilterNode *node);
 
 #endif // _FILTER_TREE_H 

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -179,7 +179,8 @@ IndexIter* IndexIter_Create(Index *idx, SIType type) {
  * Returns 1 if the filter was a comparison type that can be translated into a bound
  * (effectively, any type but '!='), which indicates that it is now redundant. */
 bool IndexIter_ApplyBound(IndexIter *iter, FT_PredicateNode *filter) {
-  return skiplistIter_UpdateBound(iter, &filter->constVal, filter->op);
+  // return skiplistIter_UpdateBound(iter, &filter->constVal, filter->op);
+  return false;
 }
 
 NodeID* IndexIter_Next(IndexIter *iter) {

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -179,8 +179,7 @@ IndexIter* IndexIter_Create(Index *idx, SIType type) {
  * Returns 1 if the filter was a comparison type that can be translated into a bound
  * (effectively, any type but '!='), which indicates that it is now redundant. */
 bool IndexIter_ApplyBound(IndexIter *iter, FT_PredicateNode *filter) {
-  // return skiplistIter_UpdateBound(iter, &filter->constVal, filter->op);
-  return false;
+  return skiplistIter_UpdateBound(iter, &filter->rhs->operand.constant, filter->op);
 }
 
 NodeID* IndexIter_Next(IndexIter *iter) {

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -33,18 +33,21 @@ int compareStrings(SIValue *a, SIValue *b) {
 }
 
 int compareNumerics(SIValue *a, SIValue *b) {
-  return a->doubleval - b->doubleval;
+  double diff = a->doubleval - b->doubleval;
+  return COMPARE_RETVAL(diff);
 }
 
 /* The index must maintain its own copy of the indexed SIValue
  * so that it becomes outdated but not broken by updates to the property. */
-void cloneKey(SIValue **property) {
-  SIValue *clone = *property;
-  *clone = SI_Clone(*clone);
+SIValue* cloneKey(SIValue *property) {
+  SIValue *clone = malloc(sizeof(SIValue));
+  *clone = SI_Clone(*property);
+  return clone;
 }
 
 void freeKey(SIValue *key) {
   SIValue_Free(key);
+  free(key);
 }
 
 /* Construct key and retrieve index from Redis keyspace */
@@ -178,8 +181,8 @@ IndexIter* IndexIter_Create(Index *idx, SIType type) {
  * it narrows the iterator range.
  * Returns 1 if the filter was a comparison type that can be translated into a bound
  * (effectively, any type but '!='), which indicates that it is now redundant. */
-bool IndexIter_ApplyBound(IndexIter *iter, FT_PredicateNode *filter) {
-  return skiplistIter_UpdateBound(iter, &filter->rhs->operand.constant, filter->op);
+bool IndexIter_ApplyBound(IndexIter *iter, SIValue *bound, int op) {
+  return skiplistIter_UpdateBound(iter, bound, op);
 }
 
 NodeID* IndexIter_Next(IndexIter *iter) {

--- a/src/index/index.h
+++ b/src/index/index.h
@@ -59,7 +59,7 @@ IndexIter* IndexIter_Create(Index *idx, SIType type);
 
 /* Update the lower or upper bound of an index iterator based on a constant predicate filter
  * (if that filter represents a narrower bound than the current one). */
-bool IndexIter_ApplyBound(IndexIter *iter, FT_PredicateNode *filter);
+bool IndexIter_ApplyBound(IndexIter *iter, SIValue *bound, int op);
 
 /* Returns a pointer to the next Node ID in the index, or NULL if the iterator has been depleted. */
 GrB_Index* IndexIter_Next(IndexIter *iter);

--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -145,6 +145,7 @@ AST_Validation _Validate_RETURN_Clause(const AST_Query *ast, char **reason) {
 
   // Make sure all referenced function do exists.
   TrieMap *ref_functions = NewTrieMap();
+  // TODO check WHERE too
   ReturnClause_ReferredFunctions(ast->returnNode, ref_functions);
 
   void *value;

--- a/src/parser/ast_arithmetic_expression.c
+++ b/src/parser/ast_arithmetic_expression.c
@@ -66,11 +66,6 @@ void AR_EXP_GetFunctions(const AST_ArithmeticExpressionNode *exp, TrieMap *funct
 	}
 }
 
-int AR_EXP_GetOpType(AST_ArithmeticExpressionNode *exp) {
-  if (exp->type == AST_AR_EXP_OPERAND) return exp->operand.type;
-  return 0;
-}
-
 void Free_AST_ArithmeticExpressionNode(AST_ArithmeticExpressionNode *arExpNode) {
 	/* Free arithmetic expression operation. */
 	if(arExpNode->type == AST_AR_EXP_OP) {

--- a/src/parser/ast_arithmetic_expression.c
+++ b/src/parser/ast_arithmetic_expression.c
@@ -49,7 +49,7 @@ void AR_EXP_GetAliases(const AST_ArithmeticExpressionNode *exp, TrieMap *aliases
     /* Check specific operand */
     if (exp->operand.type == AST_AR_EXP_VARIADIC) {
 			char *alias = exp->operand.variadic.alias;
-			TrieMap_Add(aliases, alias, strlen(alias), NULL, NULL);
+			if (alias) TrieMap_Add(aliases, alias, strlen(alias), NULL, NULL);
     }
   }
 }

--- a/src/parser/ast_arithmetic_expression.c
+++ b/src/parser/ast_arithmetic_expression.c
@@ -66,6 +66,11 @@ void AR_EXP_GetFunctions(const AST_ArithmeticExpressionNode *exp, TrieMap *funct
 	}
 }
 
+int AR_EXP_GetOpType(AST_ArithmeticExpressionNode *exp) {
+  if (exp->type == AST_AR_EXP_OPERAND) return exp->operand.type;
+  return 0;
+}
+
 void Free_AST_ArithmeticExpressionNode(AST_ArithmeticExpressionNode *arExpNode) {
 	/* Free arithmetic expression operation. */
 	if(arExpNode->type == AST_AR_EXP_OP) {
@@ -83,6 +88,6 @@ void Free_AST_ArithmeticExpressionNode(AST_ArithmeticExpressionNode *arExpNode) 
 			free(arExpNode->operand.variadic.property);
 		}
 	}
-	/* Finaly we can free the node. */
+	/* Finally we can free the node. */
 	free(arExpNode);
 }

--- a/src/parser/ast_arithmetic_expression.h
+++ b/src/parser/ast_arithmetic_expression.h
@@ -20,8 +20,8 @@ typedef enum {
 } AST_ArithmeticExpression_NodeType;
 
 typedef enum {
-    AST_AR_EXP_CONSTANT = 1,
-    AST_AR_EXP_VARIADIC = 2,
+    AST_AR_EXP_CONSTANT,
+    AST_AR_EXP_VARIADIC,
 } AST_ArithmeticExpression_OperandNodeType;
 
 typedef struct {
@@ -44,7 +44,7 @@ typedef struct {
 
 typedef struct {
 	union {
-		AST_ArithmeticExpressionOperand operand;
+        AST_ArithmeticExpressionOperand operand;
         AST_ArithmeticExpressionOP op;
     };
     AST_ArithmeticExpression_NodeType type;

--- a/src/parser/ast_arithmetic_expression.h
+++ b/src/parser/ast_arithmetic_expression.h
@@ -60,8 +60,6 @@ void AR_EXP_GetAliases(const AST_ArithmeticExpressionNode *exp, TrieMap *aliases
 /* Find all functions in expression */
 void AR_EXP_GetFunctions(const AST_ArithmeticExpressionNode *exp, TrieMap *functions);
 
-int AR_EXP_GetOpType(AST_ArithmeticExpressionNode *exp);
-
 void Free_AST_ArithmeticExpressionNode(AST_ArithmeticExpressionNode *arExpNode);
 
 #endif

--- a/src/parser/ast_arithmetic_expression.h
+++ b/src/parser/ast_arithmetic_expression.h
@@ -20,13 +20,13 @@ typedef enum {
 } AST_ArithmeticExpression_NodeType;
 
 typedef enum {
-    AST_AR_EXP_CONSTANT,
-    AST_AR_EXP_VARIADIC,
+    AST_AR_EXP_CONSTANT = 1,
+    AST_AR_EXP_VARIADIC = 2,
 } AST_ArithmeticExpression_OperandNodeType;
 
 typedef struct {
     char *function; /* Name of operation. */
-	Vector *args;	/* Vector of AST_ArithmeticExpressionNode pointers. */
+    Vector *args;	/* Vector of AST_ArithmeticExpressionNode pointers. */
 } AST_ArithmeticExpressionOP;
 
 /* OperandNode represents either a constant numeric value, 
@@ -59,6 +59,8 @@ void AR_EXP_GetAliases(const AST_ArithmeticExpressionNode *exp, TrieMap *aliases
 
 /* Find all functions in expression */
 void AR_EXP_GetFunctions(const AST_ArithmeticExpressionNode *exp, TrieMap *functions);
+
+int AR_EXP_GetOpType(AST_ArithmeticExpressionNode *exp);
 
 void Free_AST_ArithmeticExpressionNode(AST_ArithmeticExpressionNode *arExpNode);
 

--- a/src/parser/clauses/where.c
+++ b/src/parser/clauses/where.c
@@ -1,9 +1,9 @@
 /*
-* Copyright 2018-2019 Redis Labs Ltd. and Contributors
-*
-* This file is available under the Apache License, Version 2.0,
-* modified with the Commons Clause restriction.
-*/
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Apache License, Version 2.0,
+ * modified with the Commons Clause restriction.
+ */
 
 #include "./where.h"
 #include <assert.h>
@@ -16,48 +16,28 @@ AST_WhereNode* New_AST_WhereNode(AST_FilterNode *filters) {
 
 AST_FilterNode* New_AST_PredicateNode(AST_ArithmeticExpressionNode *lhs, int op, AST_ArithmeticExpressionNode *rhs) {
 	AST_FilterNode *n = malloc(sizeof(AST_FilterNode));
-  n->t = N_PRED;
-  n->pn.lhs = lhs;
-  n->pn.op = op;
-  n->pn.rhs = rhs;
+	n->t = N_PRED;
+	n->pn.lhs = lhs;
+	n->pn.op = op;
+	n->pn.rhs = rhs;
 
-  return n;
+	return n;
 }
 
 AST_FilterNode *New_AST_ConditionNode(AST_FilterNode *left, int op, AST_FilterNode *right) {
-  AST_FilterNode *n = malloc(sizeof(AST_FilterNode));
-  n->t = N_COND;
-  n->cn.left = left;
-  n->cn.right = right;
-  n->cn.op = op;
+	AST_FilterNode *n = malloc(sizeof(AST_FilterNode));
+	n->t = N_COND;
+	n->cn.left = left;
+	n->cn.right = right;
+	n->cn.op = op;
 
-  return n;
+	return n;
 }
 
 void FreePredicateNode(AST_PredicateNode* predicateNode) {
-
-  // TODO free, but maybe leave arithmetic expressions alone
-  /*
-	if(predicateNode->alias) {
-		free(predicateNode->alias);
-	}
-
-	if(predicateNode->property) {
-		free(predicateNode->property);
-	}
-
-	if(predicateNode->t == N_VARYING) {
-		if(predicateNode->nodeVal.alias) {
-			free(predicateNode->nodeVal.alias);
-		}
-
-		if(predicateNode->nodeVal.property) {
-			free(predicateNode->nodeVal.property);
-		}
-	}
-  */
-
-	// TODO: Should I free constVal?
+	// Don't free arithmetic expression nodes, as they have already
+	// been freed with the filter tree
+	free(predicateNode);
 }
 
 void _WhereClause_ReferredNodes(AST_FilterNode *root, TrieMap *referred_nodes) {
@@ -67,8 +47,8 @@ void _WhereClause_ReferredNodes(AST_FilterNode *root, TrieMap *referred_nodes) {
 			_WhereClause_ReferredNodes(root->cn.right, referred_nodes);
 			break;
 		case N_PRED:
-      AR_EXP_GetAliases(root->pn.lhs, referred_nodes);
-      AR_EXP_GetAliases(root->pn.rhs, referred_nodes);
+			AR_EXP_GetAliases(root->pn.lhs, referred_nodes);
+			AR_EXP_GetAliases(root->pn.rhs, referred_nodes);
 			break;
 		default:
 			assert(0);
@@ -77,8 +57,23 @@ void _WhereClause_ReferredNodes(AST_FilterNode *root, TrieMap *referred_nodes) {
 }
 
 void WhereClause_ReferredNodes(const AST_WhereNode *where_node, TrieMap *referred_nodes) {
-	if(!where_node) return;
+	if (!where_node) return;
 	_WhereClause_ReferredNodes(where_node->filters, referred_nodes);
+}
+
+void WhereClause_ReferredFunctions(const AST_FilterNode *root, TrieMap *referred_funcs) {
+	if (!root) return;
+	if (root->t == N_PRED) {
+		// Check expressions on each side of predicate filters
+		AST_ArithmeticExpressionNode *exp = root->pn.lhs;
+		AR_EXP_GetFunctions(exp, referred_funcs);
+		exp = root->pn.rhs;
+		AR_EXP_GetFunctions(exp, referred_funcs);
+	} else {
+		// Visit both children of conditional nodes
+		WhereClause_ReferredFunctions(root->cn.left, referred_funcs);
+		WhereClause_ReferredFunctions(root->cn.right, referred_funcs);
+	}
 }
 
 void Free_AST_FilterNode(AST_FilterNode* filterNode) {

--- a/src/parser/clauses/where.h
+++ b/src/parser/clauses/where.h
@@ -11,6 +11,7 @@
 #include "../../value.h"
 #include "../../rmutil/vector.h"
 #include "../../util/triemap/triemap.h"
+#include "../ast_arithmetic_expression.h"
 
 typedef enum {
   N_PRED,
@@ -20,7 +21,13 @@ typedef enum {
 typedef enum {
 	N_CONSTANT,
 	N_VARYING,
+	N_FUNC,
 } AST_CompareValueType;
+
+typedef struct functionFilter {
+  SIValue constVal;
+  char *function; // TODO just make AR_ExpNode in parser?
+} AST_FunctionFilter;
 
 struct filterNode;
 
@@ -31,6 +38,7 @@ typedef struct {
 			char *alias;
 			char *property;
 		} nodeVal;
+    AST_FunctionFilter func;
 	};
 	AST_CompareValueType t; // Compared value type, constant/node
 	char *alias;			// Node alias
@@ -57,6 +65,8 @@ typedef struct {
 } AST_WhereNode;
 
 AST_WhereNode* New_AST_WhereNode(AST_FilterNode *filters);
+AST_FilterNode* New_AST_PredicateNode(AST_ArithmeticExpressionNode *lhs, int op, AST_ArithmeticExpressionNode *rhs);
+AST_FilterNode* New_AST_FunctionPredicateNode(AST_ArithmeticExpressionOP func, int op, SIValue value);
 AST_FilterNode* New_AST_ConstantPredicateNode(const char *alias, const char *property, int op, SIValue value);
 AST_FilterNode* New_AST_VaryingPredicateNode(const char *lAlias, const char *lProperty, int op, const char *rAlias, const char *rProperty);
 AST_FilterNode* New_AST_ConditionNode(AST_FilterNode *left, int op, AST_FilterNode *right);

--- a/src/parser/clauses/where.h
+++ b/src/parser/clauses/where.h
@@ -47,7 +47,10 @@ typedef struct {
 AST_WhereNode* New_AST_WhereNode(AST_FilterNode *filters);
 AST_FilterNode* New_AST_PredicateNode(AST_ArithmeticExpressionNode *lhs, int op, AST_ArithmeticExpressionNode *rhs);
 AST_FilterNode* New_AST_ConditionNode(AST_FilterNode *left, int op, AST_FilterNode *right);
+
 void WhereClause_ReferredNodes(const AST_WhereNode *where_node, TrieMap *referred_nodes);
+void WhereClause_ReferredFunctions(const AST_FilterNode *return_node, TrieMap *referred_funcs);
+
 void Free_AST_FilterNode(AST_FilterNode *filterNode);
 void Free_AST_WhereNode(AST_WhereNode *whereNode);
 

--- a/src/parser/clauses/where.h
+++ b/src/parser/clauses/where.h
@@ -18,32 +18,12 @@ typedef enum {
   N_COND,
 } AST_FilterNodeType;
 
-typedef enum {
-	N_CONSTANT,
-	N_VARYING,
-	N_FUNC,
-} AST_CompareValueType;
-
-typedef struct functionFilter {
-  SIValue constVal;
-  char *function; // TODO just make AR_ExpNode in parser?
-} AST_FunctionFilter;
-
 struct filterNode;
 
 typedef struct {
-	union {
-		SIValue constVal;
-		struct {
-			char *alias;
-			char *property;
-		} nodeVal;
-    AST_FunctionFilter func;
-	};
-	AST_CompareValueType t; // Compared value type, constant/node
-	char *alias;			// Node alias
-	char *property; 		// Node property
-	int op;					// Type of comparison
+  AST_ArithmeticExpressionNode *lhs;  // Left-hand expression
+  AST_ArithmeticExpressionNode *rhs;  // Right-hand expression
+  int op;                             // Type of comparison
 } AST_PredicateNode;
 
 typedef struct conditionNode {
@@ -66,9 +46,6 @@ typedef struct {
 
 AST_WhereNode* New_AST_WhereNode(AST_FilterNode *filters);
 AST_FilterNode* New_AST_PredicateNode(AST_ArithmeticExpressionNode *lhs, int op, AST_ArithmeticExpressionNode *rhs);
-AST_FilterNode* New_AST_FunctionPredicateNode(AST_ArithmeticExpressionOP func, int op, SIValue value);
-AST_FilterNode* New_AST_ConstantPredicateNode(const char *alias, const char *property, int op, SIValue value);
-AST_FilterNode* New_AST_VaryingPredicateNode(const char *lAlias, const char *lProperty, int op, const char *rAlias, const char *rProperty);
 AST_FilterNode* New_AST_ConditionNode(AST_FilterNode *left, int op, AST_FilterNode *right);
 void WhereClause_ReferredNodes(const AST_WhereNode *where_node, TrieMap *referred_nodes);
 void Free_AST_FilterNode(AST_FilterNode *filterNode);

--- a/src/parser/grammar.c
+++ b/src/parser/grammar.c
@@ -1560,44 +1560,44 @@ static void yy_reduce(
 #line 1561 "grammar.c"
         break;
       case 46: /* cond ::= arithmetic_expression relation arithmetic_expression */
-#line 292 "grammar.y"
+#line 287 "grammar.y"
 { yylhsminor.yy130 = New_AST_PredicateNode(yymsp[-2].minor.yy58, yymsp[-1].minor.yy4, yymsp[0].minor.yy58); }
 #line 1566 "grammar.c"
   yymsp[-2].minor.yy130 = yylhsminor.yy130;
         break;
       case 47: /* cond ::= LEFT_PARENTHESIS cond RIGHT_PARENTHESIS */
-#line 294 "grammar.y"
+#line 289 "grammar.y"
 { yymsp[-2].minor.yy130 = yymsp[-1].minor.yy130; }
 #line 1572 "grammar.c"
         break;
       case 48: /* cond ::= cond AND cond */
-#line 295 "grammar.y"
+#line 290 "grammar.y"
 { yylhsminor.yy130 = New_AST_ConditionNode(yymsp[-2].minor.yy130, AND, yymsp[0].minor.yy130); }
 #line 1577 "grammar.c"
   yymsp[-2].minor.yy130 = yylhsminor.yy130;
         break;
       case 49: /* cond ::= cond OR cond */
-#line 296 "grammar.y"
+#line 291 "grammar.y"
 { yylhsminor.yy130 = New_AST_ConditionNode(yymsp[-2].minor.yy130, OR, yymsp[0].minor.yy130); }
 #line 1583 "grammar.c"
   yymsp[-2].minor.yy130 = yylhsminor.yy130;
         break;
       case 50: /* returnClause ::= RETURN returnElements */
-#line 300 "grammar.y"
+#line 295 "grammar.y"
 {
 	yymsp[-1].minor.yy120 = New_AST_ReturnNode(yymsp[0].minor.yy162, 0);
 }
 #line 1591 "grammar.c"
         break;
       case 51: /* returnClause ::= RETURN DISTINCT returnElements */
-#line 303 "grammar.y"
+#line 298 "grammar.y"
 {
 	yymsp[-2].minor.yy120 = New_AST_ReturnNode(yymsp[0].minor.yy162, 1);
 }
 #line 1598 "grammar.c"
         break;
       case 52: /* returnElements ::= returnElements COMMA returnElement */
-#line 310 "grammar.y"
+#line 305 "grammar.y"
 {
 	Vector_Push(yymsp[-2].minor.yy162, yymsp[0].minor.yy163);
 	yylhsminor.yy162 = yymsp[-2].minor.yy162;
@@ -1606,7 +1606,7 @@ static void yy_reduce(
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
       case 53: /* returnElements ::= returnElement */
-#line 315 "grammar.y"
+#line 310 "grammar.y"
 {
 	yylhsminor.yy162 = NewVector(AST_ReturnElementNode*, 1);
 	Vector_Push(yylhsminor.yy162, yymsp[0].minor.yy163);
@@ -1615,7 +1615,7 @@ static void yy_reduce(
   yymsp[0].minor.yy162 = yylhsminor.yy162;
         break;
       case 54: /* returnElement ::= arithmetic_expression */
-#line 322 "grammar.y"
+#line 317 "grammar.y"
 {
 	yylhsminor.yy163 = New_AST_ReturnElementNode(yymsp[0].minor.yy58, NULL);
 }
@@ -1623,7 +1623,7 @@ static void yy_reduce(
   yymsp[0].minor.yy163 = yylhsminor.yy163;
         break;
       case 55: /* returnElement ::= arithmetic_expression AS UQSTRING */
-#line 327 "grammar.y"
+#line 322 "grammar.y"
 {
 	yylhsminor.yy163 = New_AST_ReturnElementNode(yymsp[-2].minor.yy58, yymsp[0].minor.yy0.strval);
 }
@@ -1631,14 +1631,14 @@ static void yy_reduce(
   yymsp[-2].minor.yy163 = yylhsminor.yy163;
         break;
       case 56: /* arithmetic_expression ::= LEFT_PARENTHESIS arithmetic_expression RIGHT_PARENTHESIS */
-#line 334 "grammar.y"
+#line 329 "grammar.y"
 {
 	yymsp[-2].minor.yy58 = yymsp[-1].minor.yy58;
 }
 #line 1639 "grammar.c"
         break;
       case 57: /* arithmetic_expression ::= arithmetic_expression ADD arithmetic_expression */
-#line 346 "grammar.y"
+#line 341 "grammar.y"
 {
 	Vector *args = NewVector(AST_ArithmeticExpressionNode*, 2);
 	Vector_Push(args, yymsp[-2].minor.yy58);
@@ -1649,7 +1649,7 @@ static void yy_reduce(
   yymsp[-2].minor.yy58 = yylhsminor.yy58;
         break;
       case 58: /* arithmetic_expression ::= arithmetic_expression DASH arithmetic_expression */
-#line 353 "grammar.y"
+#line 348 "grammar.y"
 {
 	Vector *args = NewVector(AST_ArithmeticExpressionNode*, 2);
 	Vector_Push(args, yymsp[-2].minor.yy58);
@@ -1660,7 +1660,7 @@ static void yy_reduce(
   yymsp[-2].minor.yy58 = yylhsminor.yy58;
         break;
       case 59: /* arithmetic_expression ::= arithmetic_expression MUL arithmetic_expression */
-#line 360 "grammar.y"
+#line 355 "grammar.y"
 {
 	Vector *args = NewVector(AST_ArithmeticExpressionNode*, 2);
 	Vector_Push(args, yymsp[-2].minor.yy58);
@@ -1671,7 +1671,7 @@ static void yy_reduce(
   yymsp[-2].minor.yy58 = yylhsminor.yy58;
         break;
       case 60: /* arithmetic_expression ::= arithmetic_expression DIV arithmetic_expression */
-#line 367 "grammar.y"
+#line 362 "grammar.y"
 {
 	Vector *args = NewVector(AST_ArithmeticExpressionNode*, 2);
 	Vector_Push(args, yymsp[-2].minor.yy58);
@@ -1682,7 +1682,7 @@ static void yy_reduce(
   yymsp[-2].minor.yy58 = yylhsminor.yy58;
         break;
       case 61: /* arithmetic_expression ::= UQSTRING LEFT_PARENTHESIS arithmetic_expression_list RIGHT_PARENTHESIS */
-#line 375 "grammar.y"
+#line 370 "grammar.y"
 {
 	yylhsminor.yy58 = New_AST_AR_EXP_OpNode(yymsp[-3].minor.yy0.strval, yymsp[-1].minor.yy162);
 }
@@ -1690,7 +1690,7 @@ static void yy_reduce(
   yymsp[-3].minor.yy58 = yylhsminor.yy58;
         break;
       case 62: /* arithmetic_expression ::= value */
-#line 380 "grammar.y"
+#line 375 "grammar.y"
 {
 	yylhsminor.yy58 = New_AST_AR_EXP_ConstOperandNode(yymsp[0].minor.yy78);
 }
@@ -1698,7 +1698,7 @@ static void yy_reduce(
   yymsp[0].minor.yy58 = yylhsminor.yy58;
         break;
       case 63: /* arithmetic_expression ::= variable */
-#line 385 "grammar.y"
+#line 380 "grammar.y"
 {
 	yylhsminor.yy58 = New_AST_AR_EXP_VariableOperandNode(yymsp[0].minor.yy36->alias, yymsp[0].minor.yy36->property);
 }
@@ -1706,7 +1706,7 @@ static void yy_reduce(
   yymsp[0].minor.yy58 = yylhsminor.yy58;
         break;
       case 64: /* arithmetic_expression_list ::= arithmetic_expression_list COMMA arithmetic_expression */
-#line 391 "grammar.y"
+#line 386 "grammar.y"
 {
 	Vector_Push(yymsp[-2].minor.yy162, yymsp[0].minor.yy58);
 	yylhsminor.yy162 = yymsp[-2].minor.yy162;
@@ -1715,7 +1715,7 @@ static void yy_reduce(
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
       case 65: /* arithmetic_expression_list ::= arithmetic_expression */
-#line 395 "grammar.y"
+#line 390 "grammar.y"
 {
 	yylhsminor.yy162 = NewVector(AST_ArithmeticExpressionNode*, 1);
 	Vector_Push(yylhsminor.yy162, yymsp[0].minor.yy58);
@@ -1724,7 +1724,7 @@ static void yy_reduce(
   yymsp[0].minor.yy162 = yylhsminor.yy162;
         break;
       case 66: /* variable ::= UQSTRING */
-#line 402 "grammar.y"
+#line 397 "grammar.y"
 {
 	yylhsminor.yy36 = New_AST_Variable(yymsp[0].minor.yy0.strval, NULL);
 }
@@ -1732,7 +1732,7 @@ static void yy_reduce(
   yymsp[0].minor.yy36 = yylhsminor.yy36;
         break;
       case 67: /* variable ::= UQSTRING DOT UQSTRING */
-#line 406 "grammar.y"
+#line 401 "grammar.y"
 {
 	yylhsminor.yy36 = New_AST_Variable(yymsp[-2].minor.yy0.strval, yymsp[0].minor.yy0.strval);
 }
@@ -1740,35 +1740,35 @@ static void yy_reduce(
   yymsp[-2].minor.yy36 = yylhsminor.yy36;
         break;
       case 68: /* orderClause ::= */
-#line 412 "grammar.y"
+#line 407 "grammar.y"
 {
 	yymsp[1].minor.yy29 = NULL;
 }
 #line 1748 "grammar.c"
         break;
       case 69: /* orderClause ::= ORDER BY columnNameList */
-#line 415 "grammar.y"
+#line 410 "grammar.y"
 {
 	yymsp[-2].minor.yy29 = New_AST_OrderNode(yymsp[0].minor.yy162, ORDER_DIR_ASC);
 }
 #line 1755 "grammar.c"
         break;
       case 70: /* orderClause ::= ORDER BY columnNameList ASC */
-#line 418 "grammar.y"
+#line 413 "grammar.y"
 {
 	yymsp[-3].minor.yy29 = New_AST_OrderNode(yymsp[-1].minor.yy162, ORDER_DIR_ASC);
 }
 #line 1762 "grammar.c"
         break;
       case 71: /* orderClause ::= ORDER BY columnNameList DESC */
-#line 421 "grammar.y"
+#line 416 "grammar.y"
 {
 	yymsp[-3].minor.yy29 = New_AST_OrderNode(yymsp[-1].minor.yy162, ORDER_DIR_DESC);
 }
 #line 1769 "grammar.c"
         break;
       case 72: /* columnNameList ::= columnNameList COMMA columnName */
-#line 426 "grammar.y"
+#line 421 "grammar.y"
 {
 	Vector_Push(yymsp[-2].minor.yy162, yymsp[0].minor.yy22);
 	yylhsminor.yy162 = yymsp[-2].minor.yy162;
@@ -1777,7 +1777,7 @@ static void yy_reduce(
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
       case 73: /* columnNameList ::= columnName */
-#line 430 "grammar.y"
+#line 425 "grammar.y"
 {
 	yylhsminor.yy162 = NewVector(AST_ColumnNode*, 1);
 	Vector_Push(yylhsminor.yy162, yymsp[0].minor.yy22);
@@ -1786,7 +1786,7 @@ static void yy_reduce(
   yymsp[0].minor.yy162 = yylhsminor.yy162;
         break;
       case 74: /* columnName ::= variable */
-#line 436 "grammar.y"
+#line 431 "grammar.y"
 {
 	if(yymsp[0].minor.yy36->property != NULL) {
 		yylhsminor.yy22 = AST_ColumnNodeFromVariable(yymsp[0].minor.yy36);
@@ -1800,89 +1800,89 @@ static void yy_reduce(
   yymsp[0].minor.yy22 = yylhsminor.yy22;
         break;
       case 75: /* limitClause ::= */
-#line 448 "grammar.y"
+#line 443 "grammar.y"
 {
 	yymsp[1].minor.yy135 = NULL;
 }
 #line 1808 "grammar.c"
         break;
       case 76: /* limitClause ::= LIMIT INTEGER */
-#line 451 "grammar.y"
+#line 446 "grammar.y"
 {
 	yymsp[-1].minor.yy135 = New_AST_LimitNode(yymsp[0].minor.yy0.intval);
 }
 #line 1815 "grammar.c"
         break;
       case 77: /* relation ::= EQ */
-#line 457 "grammar.y"
+#line 452 "grammar.y"
 { yymsp[0].minor.yy4 = EQ; }
 #line 1820 "grammar.c"
         break;
       case 78: /* relation ::= GT */
-#line 458 "grammar.y"
+#line 453 "grammar.y"
 { yymsp[0].minor.yy4 = GT; }
 #line 1825 "grammar.c"
         break;
       case 79: /* relation ::= LT */
-#line 459 "grammar.y"
+#line 454 "grammar.y"
 { yymsp[0].minor.yy4 = LT; }
 #line 1830 "grammar.c"
         break;
       case 80: /* relation ::= LE */
-#line 460 "grammar.y"
+#line 455 "grammar.y"
 { yymsp[0].minor.yy4 = LE; }
 #line 1835 "grammar.c"
         break;
       case 81: /* relation ::= GE */
-#line 461 "grammar.y"
+#line 456 "grammar.y"
 { yymsp[0].minor.yy4 = GE; }
 #line 1840 "grammar.c"
         break;
       case 82: /* relation ::= NE */
-#line 462 "grammar.y"
+#line 457 "grammar.y"
 { yymsp[0].minor.yy4 = NE; }
 #line 1845 "grammar.c"
         break;
       case 83: /* value ::= INTEGER */
-#line 473 "grammar.y"
+#line 468 "grammar.y"
 {  yylhsminor.yy78 = SI_DoubleVal(yymsp[0].minor.yy0.intval); }
 #line 1850 "grammar.c"
   yymsp[0].minor.yy78 = yylhsminor.yy78;
         break;
       case 84: /* value ::= DASH INTEGER */
-#line 474 "grammar.y"
+#line 469 "grammar.y"
 {  yymsp[-1].minor.yy78 = SI_DoubleVal(-yymsp[0].minor.yy0.intval); }
 #line 1856 "grammar.c"
         break;
       case 85: /* value ::= STRING */
-#line 475 "grammar.y"
+#line 470 "grammar.y"
 {  yylhsminor.yy78 = SI_StringVal(yymsp[0].minor.yy0.strval); }
 #line 1861 "grammar.c"
   yymsp[0].minor.yy78 = yylhsminor.yy78;
         break;
       case 86: /* value ::= FLOAT */
-#line 476 "grammar.y"
+#line 471 "grammar.y"
 {  yylhsminor.yy78 = SI_DoubleVal(yymsp[0].minor.yy0.dval); }
 #line 1867 "grammar.c"
   yymsp[0].minor.yy78 = yylhsminor.yy78;
         break;
       case 87: /* value ::= DASH FLOAT */
-#line 477 "grammar.y"
+#line 472 "grammar.y"
 {  yymsp[-1].minor.yy78 = SI_DoubleVal(-yymsp[0].minor.yy0.dval); }
 #line 1873 "grammar.c"
         break;
       case 88: /* value ::= TRUE */
-#line 478 "grammar.y"
+#line 473 "grammar.y"
 { yymsp[0].minor.yy78 = SI_BoolVal(1); }
 #line 1878 "grammar.c"
         break;
       case 89: /* value ::= FALSE */
-#line 479 "grammar.y"
+#line 474 "grammar.y"
 { yymsp[0].minor.yy78 = SI_BoolVal(0); }
 #line 1883 "grammar.c"
         break;
       case 90: /* value ::= NULLVAL */
-#line 480 "grammar.y"
+#line 475 "grammar.y"
 { yymsp[0].minor.yy78 = SI_NullVal(); }
 #line 1888 "grammar.c"
         break;
@@ -2163,7 +2163,7 @@ void Parse(
 #endif
   return;
 }
-#line 482 "grammar.y"
+#line 477 "grammar.y"
 
 
 	/* Definitions of flex stuff */

--- a/src/parser/grammar.c
+++ b/src/parser/grammar.c
@@ -136,17 +136,17 @@ typedef union {
 #define ParseARG_PDECL , parseCtx *ctx 
 #define ParseARG_FETCH  parseCtx *ctx  = yypParser->ctx 
 #define ParseARG_STORE yypParser->ctx  = ctx 
-#define YYNSTATE             109
-#define YYNRULE              92
+#define YYNSTATE             107
+#define YYNRULE              91
 #define YYNTOKEN             48
-#define YY_MAX_SHIFT         108
-#define YY_MIN_SHIFTREDUCE   172
-#define YY_MAX_SHIFTREDUCE   263
-#define YY_ERROR_ACTION      264
-#define YY_ACCEPT_ACTION     265
-#define YY_NO_ACTION         266
-#define YY_MIN_REDUCE        267
-#define YY_MAX_REDUCE        358
+#define YY_MAX_SHIFT         106
+#define YY_MIN_SHIFTREDUCE   168
+#define YY_MAX_SHIFTREDUCE   258
+#define YY_ERROR_ACTION      259
+#define YY_ACCEPT_ACTION     260
+#define YY_NO_ACTION         261
+#define YY_MIN_REDUCE        262
+#define YY_MAX_REDUCE        352
 /************* End control #defines *******************************************/
 
 /* Define the yytestcase() macro to be a no-op if is not already defined
@@ -212,107 +212,113 @@ typedef union {
 **  yy_default[]       Default action for each state.
 **
 *********** Begin parsing tables **********************************************/
-#define YY_ACTTAB_COUNT (260)
+#define YY_ACTTAB_COUNT (284)
 static const YYACTIONTYPE yy_action[] = {
- /*     0 */   314,  108,  265,   54,   64,  273,  276,  331,   57,  331,
- /*    10 */    56,  274,  275,   95,   72,  330,   64,  330,   66,   10,
- /*    20 */   103,  321,   26,   64,  331,   58,  234,   14,   13,    6,
- /*    30 */    76,  187,  330,   22,    2,   64,   18,   66,   10,  288,
- /*    40 */    81,  256,   87,  258,  259,  261,  262,  263,    1,   11,
- /*    50 */     9,    8,    7,  256,   45,  258,  259,  261,  262,  263,
- /*    60 */   256,  105,  258,  259,  261,  262,  263,  250,  251,  254,
- /*    70 */   252,  253,  256,   21,  258,  259,  261,  262,  263,  331,
- /*    80 */    56,   11,    9,    8,    7,   47,  342,  330,  243,  244,
- /*    90 */   101,  321,  331,   59,   11,    9,    8,    7,  229,   89,
- /*   100 */   330,  340,  255,  331,   56,   65,  331,  328,   82,  287,
- /*   110 */    81,  330,  331,  327,  330,  320,  331,   67,   85,   33,
- /*   120 */   330,  331,   55,   42,  330,   16,  102,  331,   63,  330,
- /*   130 */    45,   93,   34,   53,   15,  330,   38,  270,   50,  342,
- /*   140 */   100,   91,   73,   45,   32,   39,   32,   27,   99,  290,
- /*   150 */    74,  290,  290,   61,  341,   28,   30,   35,   78,   29,
- /*   160 */    45,   60,  290,    3,   28,   30,    8,    7,  257,   88,
- /*   170 */   316,  260,   62,   94,  220,   70,  104,  280,   36,   68,
- /*   180 */    80,   83,  200,   84,   25,   90,   96,   45,  107,   86,
- /*   190 */    92,  272,  291,  310,   98,   97,  106,   48,    1,   49,
- /*   200 */    31,   52,  268,   12,   51,  188,  189,   69,   37,   71,
- /*   210 */    30,   20,  218,   75,   24,   77,  201,    5,  207,  210,
- /*   220 */    79,   40,   19,   41,  205,  249,   23,  203,  211,  209,
- /*   230 */   208,  206,  204,   43,   44,   46,  202,  228,  240,  267,
- /*   240 */   266,    4,  266,  213,  266,  266,  266,  266,  266,  266,
- /*   250 */   266,  266,  266,  104,  266,  266,  266,  266,  266,   17,
+ /*     0 */    80,  282,   79,   16,   14,   13,   12,  245,  246,  249,
+ /*    10 */   247,  248,   66,  325,   28,  325,   27,  283,   79,  103,
+ /*    20 */   224,  324,   76,  324,   62,   66,   68,   15,   43,   31,
+ /*    30 */    16,   14,   13,   12,  245,  246,  249,  247,  248,   68,
+ /*    40 */    15,    2,  250,   66,   16,   14,   13,   12,  336,  251,
+ /*    50 */    40,  253,  254,  256,  257,  258,    9,   68,    4,    3,
+ /*    60 */     5,  224,  251,  334,  253,  254,  256,  257,  258,  250,
+ /*    70 */    66,   16,   14,   13,   12,   16,   14,   13,   12,   93,
+ /*    80 */   251,   72,  253,  254,  256,  257,  258,  106,  260,   55,
+ /*    90 */    87,  268,  271,  325,   61,   19,   18,  269,  270,  183,
+ /*   100 */    74,  324,  100,   89,   23,   48,   67,  251,  336,  253,
+ /*   110 */   254,  256,  257,  258,   70,    1,  325,   28,  325,   57,
+ /*   120 */   325,   57,   63,  335,  324,  310,  324,   86,  324,  101,
+ /*   130 */   315,   99,  315,  325,   28,  325,   57,  325,   58,   83,
+ /*   140 */    34,  324,   64,  324,   85,  324,   92,  314,   37,  325,
+ /*   150 */    59,   46,  325,   60,  325,  322,   46,  324,  325,  321,
+ /*   160 */   324,   97,  324,  325,   69,  196,  324,  325,   56,  325,
+ /*   170 */    65,  324,   21,   46,   54,  324,  275,  324,  265,   51,
+ /*   180 */    98,   20,  252,   39,   33,  255,   75,   91,   35,  285,
+ /*   190 */    33,    3,    5,   13,   12,  285,   26,   32,   36,   46,
+ /*   200 */    78,  229,  285,  285,   11,    7,   30,   46,   81,   82,
+ /*   210 */   215,  238,  239,   84,   94,  105,   88,  267,   90,   96,
+ /*   220 */   286,  102,   49,  305,   95,  104,    1,  263,   50,    6,
+ /*   230 */   184,   52,   71,  185,   53,   17,   38,   73,   25,    5,
+ /*   240 */   197,   77,   10,   24,  203,  206,   41,  207,   42,  201,
+ /*   250 */    44,  202,  205,  204,  199,  262,  200,  209,   29,  198,
+ /*   260 */    47,   45,  223,  235,  261,  261,    8,  261,  102,  261,
+ /*   270 */   261,  261,  244,  261,  261,  261,  261,  261,  261,  261,
+ /*   280 */   261,  261,  261,   22,
 };
 static const YYCODETYPE yy_lookahead[] = {
- /*     0 */    76,   49,   50,   51,    4,   53,   54,   68,   69,   68,
- /*    10 */    69,   59,   60,   76,   62,   76,    4,   76,   18,   19,
- /*    20 */    79,   80,   19,    4,   68,   69,   20,   12,   13,   23,
- /*    30 */    18,   16,   76,   78,   34,    4,   21,   18,   19,   67,
- /*    40 */    68,   41,   17,   43,   44,   45,   46,   47,   33,    3,
- /*    50 */     4,    5,    6,   41,   29,   43,   44,   45,   46,   47,
- /*    60 */    41,   18,   43,   44,   45,   46,   47,    7,    8,    9,
- /*    70 */    10,   11,   41,   23,   43,   44,   45,   46,   47,   68,
- /*    80 */    69,    3,    4,    5,    6,   71,   68,   76,   38,   39,
- /*    90 */    79,   80,   68,   69,    3,    4,    5,    6,   20,   73,
- /*   100 */    76,   83,   42,   68,   69,   81,   68,   69,   66,   67,
- /*   110 */    68,   76,   68,   69,   76,   80,   68,   69,   17,   18,
- /*   120 */    76,   68,   69,    4,   76,   13,   35,   68,   69,   76,
- /*   130 */    29,   17,   18,   53,   22,   76,   24,   57,   58,   68,
- /*   140 */    61,   73,   61,   29,   65,   26,   65,   65,   17,   70,
- /*   150 */    77,   70,   70,   82,   83,    1,    2,   65,   18,   19,
- /*   160 */    29,   77,   70,   19,    1,    2,    5,    6,   41,   73,
- /*   170 */    77,   44,   77,   73,   20,   19,   32,   64,   63,   17,
- /*   180 */    72,   74,   18,   73,   27,   74,   18,   29,   40,   73,
- /*   190 */    73,   56,   70,   75,   73,   75,   36,   55,   33,   54,
- /*   200 */    31,   54,   56,   52,   55,   18,   20,   18,   15,   14,
- /*   210 */     2,   23,   18,   32,   18,   32,   18,    7,    4,   28,
- /*   220 */    23,   18,   23,   18,   20,   41,   17,   20,   28,   28,
- /*   230 */    28,   25,   20,   18,   23,   18,   20,   18,   18,    0,
- /*   240 */    84,   23,   84,   30,   84,   84,   84,   84,   84,   84,
- /*   250 */    84,   84,   84,   32,   84,   84,   84,   84,   84,   37,
- /*   260 */    84,   84,   84,   84,   84,   84,   84,   84,   84,   84,
- /*   270 */    84,   84,   84,   84,   84,   84,   84,   84,   84,   84,
- /*   280 */    84,   84,   84,   84,   84,   84,   84,   84,   84,   84,
+ /*     0 */    66,   67,   68,    3,    4,    5,    6,    7,    8,    9,
+ /*    10 */    10,   11,    4,   68,   69,   68,   69,   67,   68,   18,
+ /*    20 */    20,   76,   77,   76,   77,    4,   18,   19,    4,   19,
+ /*    30 */     3,    4,    5,    6,    7,    8,    9,   10,   11,   18,
+ /*    40 */    19,   33,   42,    4,    3,    4,    5,    6,   68,   41,
+ /*    50 */    26,   43,   44,   45,   46,   47,   78,   18,   19,    1,
+ /*    60 */     2,   20,   41,   83,   43,   44,   45,   46,   47,   42,
+ /*    70 */     4,    3,    4,    5,    6,    3,    4,    5,    6,   76,
+ /*    80 */    41,   19,   43,   44,   45,   46,   47,   49,   50,   51,
+ /*    90 */    73,   53,   54,   68,   69,   12,   13,   59,   60,   16,
+ /*   100 */    62,   76,   34,   73,   21,   71,   81,   41,   68,   43,
+ /*   110 */    44,   45,   46,   47,   17,   32,   68,   69,   68,   69,
+ /*   120 */    68,   69,   82,   83,   76,   77,   76,   73,   76,   79,
+ /*   130 */    80,   79,   80,   68,   69,   68,   69,   68,   69,   17,
+ /*   140 */    18,   76,   77,   76,   17,   76,   73,   80,   63,   68,
+ /*   150 */    69,   29,   68,   69,   68,   69,   29,   76,   68,   69,
+ /*   160 */    76,   17,   76,   68,   69,   18,   76,   68,   69,   68,
+ /*   170 */    69,   76,   13,   29,   53,   76,   64,   76,   57,   58,
+ /*   180 */    61,   22,   41,   24,   65,   44,   61,   17,   18,   70,
+ /*   190 */    65,    1,    2,    5,    6,   70,   23,   65,   65,   29,
+ /*   200 */    72,   20,   70,   70,   23,   19,   27,   29,   74,   73,
+ /*   210 */    20,   38,   39,   73,   18,   40,   74,   56,   73,   73,
+ /*   220 */    70,   35,   55,   75,   75,   36,   32,   56,   54,   31,
+ /*   230 */    18,   55,   18,   20,   54,   52,   15,   14,   23,    2,
+ /*   240 */    18,   23,    7,   23,    4,   28,   18,   28,   18,   20,
+ /*   250 */    18,   25,   28,   28,   20,    0,   20,   30,   17,   20,
+ /*   260 */    18,   23,   18,   18,   84,   84,   23,   84,   35,   84,
+ /*   270 */    84,   84,   41,   84,   84,   84,   84,   84,   84,   84,
+ /*   280 */    84,   84,   84,   37,   84,   84,   84,   84,   84,   84,
  /*   290 */    84,   84,   84,   84,   84,   84,   84,   84,   84,   84,
- /*   300 */    84,   84,   84,   84,   84,   84,   84,   84,
+ /*   300 */    84,   84,   84,   84,   84,   84,   84,   84,   84,   84,
+ /*   310 */    84,   84,   84,   84,   84,   84,   84,   84,   84,   84,
+ /*   320 */    84,   84,   84,   84,   84,   84,   84,   84,   84,   84,
+ /*   330 */    84,   84,
 };
-#define YY_SHIFT_COUNT    (108)
+#define YY_SHIFT_COUNT    (106)
 #define YY_SHIFT_MIN      (0)
-#define YY_SHIFT_MAX      (239)
+#define YY_SHIFT_MAX      (255)
 static const unsigned short int yy_shift_ofst[] = {
- /*     0 */    15,    0,   19,   19,   19,   19,   19,   19,   19,   19,
- /*    10 */    19,   19,  112,    3,    3,   43,    3,   43,    3,   43,
- /*    20 */     3,   43,   12,   31,   60,  101,  114,  119,  140,  140,
- /*    30 */   140,  140,  119,   25,  131,  119,  156,  162,  164,  157,
- /*    40 */   158,  158,  157,  158,  168,  168,  158,    3,  148,  160,
- /*    50 */   165,  148,  160,  165,  169,   78,   91,   46,   46,   46,
- /*    60 */   154,   50,  163,  161,  127,    6,  144,  161,  187,  186,
- /*    70 */   189,  193,  195,  188,  208,  194,  181,  196,  183,  198,
- /*    80 */   197,  210,  199,  214,  191,  203,  200,  205,  201,  202,
- /*    90 */   206,  204,  207,  215,  212,  211,  209,  213,  216,  217,
- /*   100 */   188,  218,  219,  218,  220,  221,  222,  184,  239,
+ /*     0 */    83,    8,   21,   39,   39,   39,   39,   21,   21,   21,
+ /*    10 */    21,   21,   21,   21,   21,   21,   21,  159,   10,   10,
+ /*    20 */     1,   10,    1,   10,    1,   10,    1,    0,   27,   66,
+ /*    30 */   122,  170,   24,   24,  127,  144,   24,   62,   97,  147,
+ /*    40 */   179,  178,  178,  179,  178,  196,  196,  178,   10,  175,
+ /*    50 */   189,  194,  175,  189,  194,  198,   41,   68,   72,   72,
+ /*    60 */    72,   72,  190,  173,   58,  188,  141,  181,  186,  188,
+ /*    70 */   212,  213,  214,  221,  223,  215,  237,  222,  218,  235,
+ /*    80 */   220,  240,  217,  228,  219,  230,  224,  225,  226,  229,
+ /*    90 */   234,  232,  236,  238,  241,  227,  239,  242,  215,  243,
+ /*   100 */   244,  243,  245,  233,  246,  231,  255,
 };
-#define YY_REDUCE_COUNT (54)
-#define YY_REDUCE_MIN   (-76)
-#define YY_REDUCE_MAX   (151)
+#define YY_REDUCE_COUNT (55)
+#define YY_REDUCE_MIN   (-66)
+#define YY_REDUCE_MAX   (183)
 static const short yy_reduce_ofst[] = {
- /*     0 */   -48,  -59,   11,   24,   35,  -61,  -44,   38,   44,   48,
- /*    10 */    53,   59,   80,   79,   81,   42,   79,   71,   82,  -28,
- /*    20 */    92,   18,  -76,  -63,  -45,   26,   68,   14,   73,   84,
- /*    30 */    93,   95,   14,   96,  100,   14,  113,  115,  108,  107,
- /*    40 */   110,  116,  111,  117,  118,  120,  121,  122,  135,  142,
- /*    50 */   145,  146,  149,  147,  151,
+ /*     0 */    38,   50,   52,  -55,  -53,   48,   65,   25,   67,   69,
+ /*    10 */    81,   84,   86,   90,   95,   99,  101,  121,  119,  125,
+ /*    20 */   -66,  119,   40,  132,  -50,  133,  -20,  -22,  -22,    3,
+ /*    30 */    17,   30,   34,   34,   54,   73,   34,  112,   85,  128,
+ /*    40 */   134,  136,  140,  142,  145,  148,  149,  146,  150,  161,
+ /*    50 */   167,  174,  171,  176,  180,  183,
 };
 static const YYACTIONTYPE yy_default[] = {
- /*     0 */   278,  264,  264,  264,  264,  264,  264,  264,  264,  264,
- /*    10 */   264,  264,  278,  281,  264,  264,  264,  264,  264,  264,
- /*    20 */   264,  264,  264,  264,  264,  307,  307,  285,  264,  264,
- /*    30 */   264,  264,  292,  307,  307,  293,  264,  264,  264,  264,
- /*    40 */   307,  307,  264,  307,  264,  264,  307,  264,  343,  336,
- /*    50 */   271,  343,  336,  269,  311,  264,  322,  289,  332,  333,
- /*    60 */   264,  337,  312,  325,  264,  264,  334,  326,  264,  264,
- /*    70 */   264,  264,  264,  277,  317,  264,  264,  264,  264,  264,
- /*    80 */   294,  264,  286,  264,  264,  264,  264,  264,  264,  264,
- /*    90 */   264,  264,  264,  264,  264,  309,  264,  264,  264,  264,
- /*   100 */   279,  319,  264,  318,  264,  334,  264,  264,  264,
+ /*     0 */   273,  259,  259,  259,  259,  259,  259,  259,  259,  259,
+ /*    10 */   259,  259,  259,  259,  259,  259,  259,  273,  276,  259,
+ /*    20 */   259,  259,  259,  259,  259,  259,  259,  259,  259,  259,
+ /*    30 */   302,  302,  280,  287,  302,  302,  288,  259,  259,  259,
+ /*    40 */   259,  302,  302,  259,  302,  259,  259,  302,  259,  337,
+ /*    50 */   330,  266,  337,  330,  264,  306,  259,  316,  308,  284,
+ /*    60 */   326,  327,  259,  331,  307,  319,  259,  259,  328,  320,
+ /*    70 */   259,  259,  259,  259,  259,  272,  311,  259,  289,  259,
+ /*    80 */   281,  259,  259,  259,  259,  259,  259,  259,  259,  259,
+ /*    90 */   259,  259,  259,  304,  259,  259,  259,  259,  274,  313,
+ /*   100 */   259,  312,  259,  328,  259,  259,  259,
 };
 /********** End of lemon-generated parsing tables *****************************/
 
@@ -450,10 +456,10 @@ static const char *const yyTokenName[] = {
   /*   29 */ "LEFT_CURLY_BRACKET",
   /*   30 */ "RIGHT_CURLY_BRACKET",
   /*   31 */ "WHERE",
-  /*   32 */ "DOT",
-  /*   33 */ "RETURN",
-  /*   34 */ "DISTINCT",
-  /*   35 */ "AS",
+  /*   32 */ "RETURN",
+  /*   33 */ "DISTINCT",
+  /*   34 */ "AS",
+  /*   35 */ "DOT",
   /*   36 */ "ORDER",
   /*   37 */ "BY",
   /*   38 */ "ASC",
@@ -555,52 +561,51 @@ static const char *const yyRuleName[] = {
  /*  43 */ "mapLiteral ::= UQSTRING COLON value COMMA mapLiteral",
  /*  44 */ "whereClause ::=",
  /*  45 */ "whereClause ::= WHERE cond",
- /*  46 */ "cond ::= UQSTRING DOT UQSTRING relation UQSTRING DOT UQSTRING",
- /*  47 */ "cond ::= UQSTRING DOT UQSTRING relation value",
- /*  48 */ "cond ::= LEFT_PARENTHESIS cond RIGHT_PARENTHESIS",
- /*  49 */ "cond ::= cond AND cond",
- /*  50 */ "cond ::= cond OR cond",
- /*  51 */ "returnClause ::= RETURN returnElements",
- /*  52 */ "returnClause ::= RETURN DISTINCT returnElements",
- /*  53 */ "returnElements ::= returnElements COMMA returnElement",
- /*  54 */ "returnElements ::= returnElement",
- /*  55 */ "returnElement ::= arithmetic_expression",
- /*  56 */ "returnElement ::= arithmetic_expression AS UQSTRING",
- /*  57 */ "arithmetic_expression ::= LEFT_PARENTHESIS arithmetic_expression RIGHT_PARENTHESIS",
- /*  58 */ "arithmetic_expression ::= arithmetic_expression ADD arithmetic_expression",
- /*  59 */ "arithmetic_expression ::= arithmetic_expression DASH arithmetic_expression",
- /*  60 */ "arithmetic_expression ::= arithmetic_expression MUL arithmetic_expression",
- /*  61 */ "arithmetic_expression ::= arithmetic_expression DIV arithmetic_expression",
- /*  62 */ "arithmetic_expression ::= UQSTRING LEFT_PARENTHESIS arithmetic_expression_list RIGHT_PARENTHESIS",
- /*  63 */ "arithmetic_expression ::= value",
- /*  64 */ "arithmetic_expression ::= variable",
- /*  65 */ "arithmetic_expression_list ::= arithmetic_expression_list COMMA arithmetic_expression",
- /*  66 */ "arithmetic_expression_list ::= arithmetic_expression",
- /*  67 */ "variable ::= UQSTRING",
- /*  68 */ "variable ::= UQSTRING DOT UQSTRING",
- /*  69 */ "orderClause ::=",
- /*  70 */ "orderClause ::= ORDER BY columnNameList",
- /*  71 */ "orderClause ::= ORDER BY columnNameList ASC",
- /*  72 */ "orderClause ::= ORDER BY columnNameList DESC",
- /*  73 */ "columnNameList ::= columnNameList COMMA columnName",
- /*  74 */ "columnNameList ::= columnName",
- /*  75 */ "columnName ::= variable",
- /*  76 */ "limitClause ::=",
- /*  77 */ "limitClause ::= LIMIT INTEGER",
- /*  78 */ "relation ::= EQ",
- /*  79 */ "relation ::= GT",
- /*  80 */ "relation ::= LT",
- /*  81 */ "relation ::= LE",
- /*  82 */ "relation ::= GE",
- /*  83 */ "relation ::= NE",
- /*  84 */ "value ::= INTEGER",
- /*  85 */ "value ::= DASH INTEGER",
- /*  86 */ "value ::= STRING",
- /*  87 */ "value ::= FLOAT",
- /*  88 */ "value ::= DASH FLOAT",
- /*  89 */ "value ::= TRUE",
- /*  90 */ "value ::= FALSE",
- /*  91 */ "value ::= NULLVAL",
+ /*  46 */ "cond ::= arithmetic_expression relation arithmetic_expression",
+ /*  47 */ "cond ::= LEFT_PARENTHESIS cond RIGHT_PARENTHESIS",
+ /*  48 */ "cond ::= cond AND cond",
+ /*  49 */ "cond ::= cond OR cond",
+ /*  50 */ "returnClause ::= RETURN returnElements",
+ /*  51 */ "returnClause ::= RETURN DISTINCT returnElements",
+ /*  52 */ "returnElements ::= returnElements COMMA returnElement",
+ /*  53 */ "returnElements ::= returnElement",
+ /*  54 */ "returnElement ::= arithmetic_expression",
+ /*  55 */ "returnElement ::= arithmetic_expression AS UQSTRING",
+ /*  56 */ "arithmetic_expression ::= LEFT_PARENTHESIS arithmetic_expression RIGHT_PARENTHESIS",
+ /*  57 */ "arithmetic_expression ::= arithmetic_expression ADD arithmetic_expression",
+ /*  58 */ "arithmetic_expression ::= arithmetic_expression DASH arithmetic_expression",
+ /*  59 */ "arithmetic_expression ::= arithmetic_expression MUL arithmetic_expression",
+ /*  60 */ "arithmetic_expression ::= arithmetic_expression DIV arithmetic_expression",
+ /*  61 */ "arithmetic_expression ::= UQSTRING LEFT_PARENTHESIS arithmetic_expression_list RIGHT_PARENTHESIS",
+ /*  62 */ "arithmetic_expression ::= value",
+ /*  63 */ "arithmetic_expression ::= variable",
+ /*  64 */ "arithmetic_expression_list ::= arithmetic_expression_list COMMA arithmetic_expression",
+ /*  65 */ "arithmetic_expression_list ::= arithmetic_expression",
+ /*  66 */ "variable ::= UQSTRING",
+ /*  67 */ "variable ::= UQSTRING DOT UQSTRING",
+ /*  68 */ "orderClause ::=",
+ /*  69 */ "orderClause ::= ORDER BY columnNameList",
+ /*  70 */ "orderClause ::= ORDER BY columnNameList ASC",
+ /*  71 */ "orderClause ::= ORDER BY columnNameList DESC",
+ /*  72 */ "columnNameList ::= columnNameList COMMA columnName",
+ /*  73 */ "columnNameList ::= columnName",
+ /*  74 */ "columnName ::= variable",
+ /*  75 */ "limitClause ::=",
+ /*  76 */ "limitClause ::= LIMIT INTEGER",
+ /*  77 */ "relation ::= EQ",
+ /*  78 */ "relation ::= GT",
+ /*  79 */ "relation ::= LT",
+ /*  80 */ "relation ::= LE",
+ /*  81 */ "relation ::= GE",
+ /*  82 */ "relation ::= NE",
+ /*  83 */ "value ::= INTEGER",
+ /*  84 */ "value ::= DASH INTEGER",
+ /*  85 */ "value ::= STRING",
+ /*  86 */ "value ::= FLOAT",
+ /*  87 */ "value ::= DASH FLOAT",
+ /*  88 */ "value ::= TRUE",
+ /*  89 */ "value ::= FALSE",
+ /*  90 */ "value ::= NULLVAL",
 };
 #endif /* NDEBUG */
 
@@ -725,7 +730,7 @@ static void yy_destructor(
 {
 #line 284 "grammar.y"
  Free_AST_FilterNode((yypminor->yy130)); 
-#line 729 "grammar.c"
+#line 734 "grammar.c"
 }
       break;
 /********* End destructor definitions *****************************************/
@@ -1066,52 +1071,51 @@ static const struct {
   {   75,   -5 }, /* (43) mapLiteral ::= UQSTRING COLON value COMMA mapLiteral */
   {   52,    0 }, /* (44) whereClause ::= */
   {   52,   -2 }, /* (45) whereClause ::= WHERE cond */
-  {   77,   -7 }, /* (46) cond ::= UQSTRING DOT UQSTRING relation UQSTRING DOT UQSTRING */
-  {   77,   -5 }, /* (47) cond ::= UQSTRING DOT UQSTRING relation value */
-  {   77,   -3 }, /* (48) cond ::= LEFT_PARENTHESIS cond RIGHT_PARENTHESIS */
-  {   77,   -3 }, /* (49) cond ::= cond AND cond */
-  {   77,   -3 }, /* (50) cond ::= cond OR cond */
-  {   54,   -2 }, /* (51) returnClause ::= RETURN returnElements */
-  {   54,   -3 }, /* (52) returnClause ::= RETURN DISTINCT returnElements */
-  {   79,   -3 }, /* (53) returnElements ::= returnElements COMMA returnElement */
-  {   79,   -1 }, /* (54) returnElements ::= returnElement */
-  {   80,   -1 }, /* (55) returnElement ::= arithmetic_expression */
-  {   80,   -3 }, /* (56) returnElement ::= arithmetic_expression AS UQSTRING */
-  {   69,   -3 }, /* (57) arithmetic_expression ::= LEFT_PARENTHESIS arithmetic_expression RIGHT_PARENTHESIS */
-  {   69,   -3 }, /* (58) arithmetic_expression ::= arithmetic_expression ADD arithmetic_expression */
-  {   69,   -3 }, /* (59) arithmetic_expression ::= arithmetic_expression DASH arithmetic_expression */
-  {   69,   -3 }, /* (60) arithmetic_expression ::= arithmetic_expression MUL arithmetic_expression */
-  {   69,   -3 }, /* (61) arithmetic_expression ::= arithmetic_expression DIV arithmetic_expression */
-  {   69,   -4 }, /* (62) arithmetic_expression ::= UQSTRING LEFT_PARENTHESIS arithmetic_expression_list RIGHT_PARENTHESIS */
-  {   69,   -1 }, /* (63) arithmetic_expression ::= value */
-  {   69,   -1 }, /* (64) arithmetic_expression ::= variable */
-  {   81,   -3 }, /* (65) arithmetic_expression_list ::= arithmetic_expression_list COMMA arithmetic_expression */
-  {   81,   -1 }, /* (66) arithmetic_expression_list ::= arithmetic_expression */
-  {   68,   -1 }, /* (67) variable ::= UQSTRING */
-  {   68,   -3 }, /* (68) variable ::= UQSTRING DOT UQSTRING */
-  {   55,    0 }, /* (69) orderClause ::= */
-  {   55,   -3 }, /* (70) orderClause ::= ORDER BY columnNameList */
-  {   55,   -4 }, /* (71) orderClause ::= ORDER BY columnNameList ASC */
-  {   55,   -4 }, /* (72) orderClause ::= ORDER BY columnNameList DESC */
-  {   82,   -3 }, /* (73) columnNameList ::= columnNameList COMMA columnName */
-  {   82,   -1 }, /* (74) columnNameList ::= columnName */
-  {   83,   -1 }, /* (75) columnName ::= variable */
-  {   56,    0 }, /* (76) limitClause ::= */
-  {   56,   -2 }, /* (77) limitClause ::= LIMIT INTEGER */
-  {   78,   -1 }, /* (78) relation ::= EQ */
-  {   78,   -1 }, /* (79) relation ::= GT */
-  {   78,   -1 }, /* (80) relation ::= LT */
-  {   78,   -1 }, /* (81) relation ::= LE */
-  {   78,   -1 }, /* (82) relation ::= GE */
-  {   78,   -1 }, /* (83) relation ::= NE */
-  {   76,   -1 }, /* (84) value ::= INTEGER */
-  {   76,   -2 }, /* (85) value ::= DASH INTEGER */
-  {   76,   -1 }, /* (86) value ::= STRING */
-  {   76,   -1 }, /* (87) value ::= FLOAT */
-  {   76,   -2 }, /* (88) value ::= DASH FLOAT */
-  {   76,   -1 }, /* (89) value ::= TRUE */
-  {   76,   -1 }, /* (90) value ::= FALSE */
-  {   76,   -1 }, /* (91) value ::= NULLVAL */
+  {   77,   -3 }, /* (46) cond ::= arithmetic_expression relation arithmetic_expression */
+  {   77,   -3 }, /* (47) cond ::= LEFT_PARENTHESIS cond RIGHT_PARENTHESIS */
+  {   77,   -3 }, /* (48) cond ::= cond AND cond */
+  {   77,   -3 }, /* (49) cond ::= cond OR cond */
+  {   54,   -2 }, /* (50) returnClause ::= RETURN returnElements */
+  {   54,   -3 }, /* (51) returnClause ::= RETURN DISTINCT returnElements */
+  {   79,   -3 }, /* (52) returnElements ::= returnElements COMMA returnElement */
+  {   79,   -1 }, /* (53) returnElements ::= returnElement */
+  {   80,   -1 }, /* (54) returnElement ::= arithmetic_expression */
+  {   80,   -3 }, /* (55) returnElement ::= arithmetic_expression AS UQSTRING */
+  {   69,   -3 }, /* (56) arithmetic_expression ::= LEFT_PARENTHESIS arithmetic_expression RIGHT_PARENTHESIS */
+  {   69,   -3 }, /* (57) arithmetic_expression ::= arithmetic_expression ADD arithmetic_expression */
+  {   69,   -3 }, /* (58) arithmetic_expression ::= arithmetic_expression DASH arithmetic_expression */
+  {   69,   -3 }, /* (59) arithmetic_expression ::= arithmetic_expression MUL arithmetic_expression */
+  {   69,   -3 }, /* (60) arithmetic_expression ::= arithmetic_expression DIV arithmetic_expression */
+  {   69,   -4 }, /* (61) arithmetic_expression ::= UQSTRING LEFT_PARENTHESIS arithmetic_expression_list RIGHT_PARENTHESIS */
+  {   69,   -1 }, /* (62) arithmetic_expression ::= value */
+  {   69,   -1 }, /* (63) arithmetic_expression ::= variable */
+  {   81,   -3 }, /* (64) arithmetic_expression_list ::= arithmetic_expression_list COMMA arithmetic_expression */
+  {   81,   -1 }, /* (65) arithmetic_expression_list ::= arithmetic_expression */
+  {   68,   -1 }, /* (66) variable ::= UQSTRING */
+  {   68,   -3 }, /* (67) variable ::= UQSTRING DOT UQSTRING */
+  {   55,    0 }, /* (68) orderClause ::= */
+  {   55,   -3 }, /* (69) orderClause ::= ORDER BY columnNameList */
+  {   55,   -4 }, /* (70) orderClause ::= ORDER BY columnNameList ASC */
+  {   55,   -4 }, /* (71) orderClause ::= ORDER BY columnNameList DESC */
+  {   82,   -3 }, /* (72) columnNameList ::= columnNameList COMMA columnName */
+  {   82,   -1 }, /* (73) columnNameList ::= columnName */
+  {   83,   -1 }, /* (74) columnName ::= variable */
+  {   56,    0 }, /* (75) limitClause ::= */
+  {   56,   -2 }, /* (76) limitClause ::= LIMIT INTEGER */
+  {   78,   -1 }, /* (77) relation ::= EQ */
+  {   78,   -1 }, /* (78) relation ::= GT */
+  {   78,   -1 }, /* (79) relation ::= LT */
+  {   78,   -1 }, /* (80) relation ::= LE */
+  {   78,   -1 }, /* (81) relation ::= GE */
+  {   78,   -1 }, /* (82) relation ::= NE */
+  {   76,   -1 }, /* (83) value ::= INTEGER */
+  {   76,   -2 }, /* (84) value ::= DASH INTEGER */
+  {   76,   -1 }, /* (85) value ::= STRING */
+  {   76,   -1 }, /* (86) value ::= FLOAT */
+  {   76,   -2 }, /* (87) value ::= DASH FLOAT */
+  {   76,   -1 }, /* (88) value ::= TRUE */
+  {   76,   -1 }, /* (89) value ::= FALSE */
+  {   76,   -1 }, /* (90) value ::= NULLVAL */
 };
 
 static void yy_accept(yyParser*);  /* Forward Declaration */
@@ -1194,14 +1198,14 @@ static void yy_reduce(
       case 0: /* query ::= expr */
 #line 36 "grammar.y"
 { ctx->root = yymsp[0].minor.yy160; }
-#line 1198 "grammar.c"
+#line 1202 "grammar.c"
         break;
       case 1: /* expr ::= matchClause whereClause createClause returnClause orderClause limitClause */
 #line 38 "grammar.y"
 {
 	yylhsminor.yy160 = New_AST_Query(yymsp[-5].minor.yy5, yymsp[-4].minor.yy99, yymsp[-3].minor.yy28, NULL, NULL, NULL, yymsp[-2].minor.yy120, yymsp[-1].minor.yy29, yymsp[0].minor.yy135, NULL);
 }
-#line 1205 "grammar.c"
+#line 1209 "grammar.c"
   yymsp[-5].minor.yy160 = yylhsminor.yy160;
         break;
       case 2: /* expr ::= matchClause whereClause createClause */
@@ -1209,7 +1213,7 @@ static void yy_reduce(
 {
 	yylhsminor.yy160 = New_AST_Query(yymsp[-2].minor.yy5, yymsp[-1].minor.yy99, yymsp[0].minor.yy28, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 }
-#line 1213 "grammar.c"
+#line 1217 "grammar.c"
   yymsp[-2].minor.yy160 = yylhsminor.yy160;
         break;
       case 3: /* expr ::= matchClause whereClause deleteClause */
@@ -1217,7 +1221,7 @@ static void yy_reduce(
 {
 	yylhsminor.yy160 = New_AST_Query(yymsp[-2].minor.yy5, yymsp[-1].minor.yy99, NULL, NULL, NULL, yymsp[0].minor.yy143, NULL, NULL, NULL, NULL);
 }
-#line 1221 "grammar.c"
+#line 1225 "grammar.c"
   yymsp[-2].minor.yy160 = yylhsminor.yy160;
         break;
       case 4: /* expr ::= matchClause whereClause setClause */
@@ -1225,7 +1229,7 @@ static void yy_reduce(
 {
 	yylhsminor.yy160 = New_AST_Query(yymsp[-2].minor.yy5, yymsp[-1].minor.yy99, NULL, NULL, yymsp[0].minor.yy20, NULL, NULL, NULL, NULL, NULL);
 }
-#line 1229 "grammar.c"
+#line 1233 "grammar.c"
   yymsp[-2].minor.yy160 = yylhsminor.yy160;
         break;
       case 5: /* expr ::= matchClause whereClause setClause returnClause orderClause limitClause */
@@ -1233,7 +1237,7 @@ static void yy_reduce(
 {
 	yylhsminor.yy160 = New_AST_Query(yymsp[-5].minor.yy5, yymsp[-4].minor.yy99, NULL, NULL, yymsp[-3].minor.yy20, NULL, yymsp[-2].minor.yy120, yymsp[-1].minor.yy29, yymsp[0].minor.yy135, NULL);
 }
-#line 1237 "grammar.c"
+#line 1241 "grammar.c"
   yymsp[-5].minor.yy160 = yylhsminor.yy160;
         break;
       case 6: /* expr ::= createClause */
@@ -1241,7 +1245,7 @@ static void yy_reduce(
 {
 	yylhsminor.yy160 = New_AST_Query(NULL, NULL, yymsp[0].minor.yy28, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 }
-#line 1245 "grammar.c"
+#line 1249 "grammar.c"
   yymsp[0].minor.yy160 = yylhsminor.yy160;
         break;
       case 7: /* expr ::= indexClause */
@@ -1249,7 +1253,7 @@ static void yy_reduce(
 {
 	yylhsminor.yy160 = New_AST_Query(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, yymsp[0].minor.yy48);
 }
-#line 1253 "grammar.c"
+#line 1257 "grammar.c"
   yymsp[0].minor.yy160 = yylhsminor.yy160;
         break;
       case 8: /* expr ::= mergeClause */
@@ -1257,7 +1261,7 @@ static void yy_reduce(
 {
 	yylhsminor.yy160 = New_AST_Query(NULL, NULL, NULL, yymsp[0].minor.yy21, NULL, NULL, NULL, NULL, NULL, NULL);
 }
-#line 1261 "grammar.c"
+#line 1265 "grammar.c"
   yymsp[0].minor.yy160 = yylhsminor.yy160;
         break;
       case 9: /* expr ::= returnClause */
@@ -1265,7 +1269,7 @@ static void yy_reduce(
 {
 	yylhsminor.yy160 = New_AST_Query(NULL, NULL, NULL, NULL, NULL, NULL, yymsp[0].minor.yy120, NULL, NULL, NULL);
 }
-#line 1269 "grammar.c"
+#line 1273 "grammar.c"
   yymsp[0].minor.yy160 = yylhsminor.yy160;
         break;
       case 10: /* matchClause ::= MATCH chains */
@@ -1273,67 +1277,67 @@ static void yy_reduce(
 {
 	yymsp[-1].minor.yy5 = New_AST_MatchNode(yymsp[0].minor.yy162);
 }
-#line 1277 "grammar.c"
+#line 1281 "grammar.c"
         break;
       case 11: /* createClause ::= */
 #line 83 "grammar.y"
 {
 	yymsp[1].minor.yy28 = NULL;
 }
-#line 1284 "grammar.c"
+#line 1288 "grammar.c"
         break;
       case 12: /* createClause ::= CREATE chains */
 #line 87 "grammar.y"
 {
 	yymsp[-1].minor.yy28 = New_AST_CreateNode(yymsp[0].minor.yy162);
 }
-#line 1291 "grammar.c"
+#line 1295 "grammar.c"
         break;
       case 13: /* indexClause ::= indexOpToken INDEX ON indexLabel indexProp */
 #line 93 "grammar.y"
 {
   yylhsminor.yy48 = New_AST_IndexNode(yymsp[-1].minor.yy0.strval, yymsp[0].minor.yy0.strval, yymsp[-4].minor.yy57);
 }
-#line 1298 "grammar.c"
+#line 1302 "grammar.c"
   yymsp[-4].minor.yy48 = yylhsminor.yy48;
         break;
       case 14: /* indexOpToken ::= CREATE */
 #line 99 "grammar.y"
 { yymsp[0].minor.yy57 = CREATE_INDEX; }
-#line 1304 "grammar.c"
+#line 1308 "grammar.c"
         break;
       case 15: /* indexOpToken ::= DROP */
 #line 100 "grammar.y"
 { yymsp[0].minor.yy57 = DROP_INDEX; }
-#line 1309 "grammar.c"
+#line 1313 "grammar.c"
         break;
       case 16: /* indexLabel ::= COLON UQSTRING */
 #line 102 "grammar.y"
 {
   yymsp[-1].minor.yy0 = yymsp[0].minor.yy0;
 }
-#line 1316 "grammar.c"
+#line 1320 "grammar.c"
         break;
       case 17: /* indexProp ::= LEFT_PARENTHESIS UQSTRING RIGHT_PARENTHESIS */
 #line 106 "grammar.y"
 {
   yymsp[-2].minor.yy0 = yymsp[-1].minor.yy0;
 }
-#line 1323 "grammar.c"
+#line 1327 "grammar.c"
         break;
       case 18: /* mergeClause ::= MERGE chain */
 #line 112 "grammar.y"
 {
 	yymsp[-1].minor.yy21 = New_AST_MergeNode(yymsp[0].minor.yy162);
 }
-#line 1330 "grammar.c"
+#line 1334 "grammar.c"
         break;
       case 19: /* setClause ::= SET setList */
 #line 117 "grammar.y"
 {
 	yymsp[-1].minor.yy20 = New_AST_SetNode(yymsp[0].minor.yy162);
 }
-#line 1337 "grammar.c"
+#line 1341 "grammar.c"
         break;
       case 20: /* setList ::= setElement */
 #line 122 "grammar.y"
@@ -1341,7 +1345,7 @@ static void yy_reduce(
 	yylhsminor.yy162 = NewVector(AST_SetElement*, 1);
 	Vector_Push(yylhsminor.yy162, yymsp[0].minor.yy168);
 }
-#line 1345 "grammar.c"
+#line 1349 "grammar.c"
   yymsp[0].minor.yy162 = yylhsminor.yy162;
         break;
       case 21: /* setList ::= setList COMMA setElement */
@@ -1350,7 +1354,7 @@ static void yy_reduce(
 	Vector_Push(yymsp[-2].minor.yy162, yymsp[0].minor.yy168);
 	yylhsminor.yy162 = yymsp[-2].minor.yy162;
 }
-#line 1354 "grammar.c"
+#line 1358 "grammar.c"
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
       case 22: /* setElement ::= variable EQ arithmetic_expression */
@@ -1358,7 +1362,7 @@ static void yy_reduce(
 {
 	yylhsminor.yy168 = New_AST_SetElement(yymsp[-2].minor.yy36, yymsp[0].minor.yy58);
 }
-#line 1362 "grammar.c"
+#line 1366 "grammar.c"
   yymsp[-2].minor.yy168 = yylhsminor.yy168;
         break;
       case 23: /* chain ::= node */
@@ -1367,7 +1371,7 @@ static void yy_reduce(
 	yylhsminor.yy162 = NewVector(AST_GraphEntity*, 1);
 	Vector_Push(yylhsminor.yy162, yymsp[0].minor.yy69);
 }
-#line 1371 "grammar.c"
+#line 1375 "grammar.c"
   yymsp[0].minor.yy162 = yylhsminor.yy162;
         break;
       case 24: /* chain ::= chain link node */
@@ -1377,7 +1381,7 @@ static void yy_reduce(
 	Vector_Push(yymsp[-2].minor.yy162, yymsp[0].minor.yy69);
 	yylhsminor.yy162 = yymsp[-2].minor.yy162;
 }
-#line 1381 "grammar.c"
+#line 1385 "grammar.c"
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
       case 25: /* chains ::= chain */
@@ -1386,7 +1390,7 @@ static void yy_reduce(
 	yylhsminor.yy162 = NewVector(Vector*, 1);
 	Vector_Push(yylhsminor.yy162, yymsp[0].minor.yy162);
 }
-#line 1390 "grammar.c"
+#line 1394 "grammar.c"
   yymsp[0].minor.yy162 = yylhsminor.yy162;
         break;
       case 26: /* chains ::= chains COMMA chain */
@@ -1395,7 +1399,7 @@ static void yy_reduce(
 	Vector_Push(yymsp[-2].minor.yy162, yymsp[0].minor.yy162);
 	yylhsminor.yy162 = yymsp[-2].minor.yy162;
 }
-#line 1399 "grammar.c"
+#line 1403 "grammar.c"
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
       case 27: /* deleteClause ::= DELETE deleteExpression */
@@ -1403,7 +1407,7 @@ static void yy_reduce(
 {
 	yymsp[-1].minor.yy143 = New_AST_DeleteNode(yymsp[0].minor.yy162);
 }
-#line 1407 "grammar.c"
+#line 1411 "grammar.c"
         break;
       case 28: /* deleteExpression ::= UQSTRING */
 #line 170 "grammar.y"
@@ -1411,7 +1415,7 @@ static void yy_reduce(
 	yylhsminor.yy162 = NewVector(char*, 1);
 	Vector_Push(yylhsminor.yy162, yymsp[0].minor.yy0.strval);
 }
-#line 1415 "grammar.c"
+#line 1419 "grammar.c"
   yymsp[0].minor.yy162 = yylhsminor.yy162;
         break;
       case 29: /* deleteExpression ::= deleteExpression COMMA UQSTRING */
@@ -1420,7 +1424,7 @@ static void yy_reduce(
 	Vector_Push(yymsp[-2].minor.yy162, yymsp[0].minor.yy0.strval);
 	yylhsminor.yy162 = yymsp[-2].minor.yy162;
 }
-#line 1424 "grammar.c"
+#line 1428 "grammar.c"
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
       case 30: /* node ::= LEFT_PARENTHESIS UQSTRING COLON UQSTRING properties RIGHT_PARENTHESIS */
@@ -1428,28 +1432,28 @@ static void yy_reduce(
 {
 	yymsp[-5].minor.yy69 = New_AST_NodeEntity(yymsp[-4].minor.yy0.strval, yymsp[-2].minor.yy0.strval, yymsp[-1].minor.yy162);
 }
-#line 1432 "grammar.c"
+#line 1436 "grammar.c"
         break;
       case 31: /* node ::= LEFT_PARENTHESIS COLON UQSTRING properties RIGHT_PARENTHESIS */
 #line 188 "grammar.y"
 {
 	yymsp[-4].minor.yy69 = New_AST_NodeEntity(NULL, yymsp[-2].minor.yy0.strval, yymsp[-1].minor.yy162);
 }
-#line 1439 "grammar.c"
+#line 1443 "grammar.c"
         break;
       case 32: /* node ::= LEFT_PARENTHESIS UQSTRING properties RIGHT_PARENTHESIS */
 #line 193 "grammar.y"
 {
 	yymsp[-3].minor.yy69 = New_AST_NodeEntity(yymsp[-2].minor.yy0.strval, NULL, yymsp[-1].minor.yy162);
 }
-#line 1446 "grammar.c"
+#line 1450 "grammar.c"
         break;
       case 33: /* node ::= LEFT_PARENTHESIS properties RIGHT_PARENTHESIS */
 #line 198 "grammar.y"
 {
 	yymsp[-2].minor.yy69 = New_AST_NodeEntity(NULL, NULL, yymsp[-1].minor.yy162);
 }
-#line 1453 "grammar.c"
+#line 1457 "grammar.c"
         break;
       case 34: /* link ::= DASH edge RIGHT_ARROW */
 #line 205 "grammar.y"
@@ -1457,7 +1461,7 @@ static void yy_reduce(
 	yymsp[-2].minor.yy93 = yymsp[-1].minor.yy93;
 	yymsp[-2].minor.yy93->direction = N_LEFT_TO_RIGHT;
 }
-#line 1461 "grammar.c"
+#line 1465 "grammar.c"
         break;
       case 35: /* link ::= LEFT_ARROW edge DASH */
 #line 211 "grammar.y"
@@ -1465,49 +1469,49 @@ static void yy_reduce(
 	yymsp[-2].minor.yy93 = yymsp[-1].minor.yy93;
 	yymsp[-2].minor.yy93->direction = N_RIGHT_TO_LEFT;
 }
-#line 1469 "grammar.c"
+#line 1473 "grammar.c"
         break;
       case 36: /* edge ::= LEFT_BRACKET properties RIGHT_BRACKET */
 #line 218 "grammar.y"
 { 
 	yymsp[-2].minor.yy93 = New_AST_LinkEntity(NULL, NULL, yymsp[-1].minor.yy162, N_DIR_UNKNOWN);
 }
-#line 1476 "grammar.c"
+#line 1480 "grammar.c"
         break;
       case 37: /* edge ::= LEFT_BRACKET UQSTRING properties RIGHT_BRACKET */
 #line 223 "grammar.y"
 { 
 	yymsp[-3].minor.yy93 = New_AST_LinkEntity(yymsp[-2].minor.yy0.strval, NULL, yymsp[-1].minor.yy162, N_DIR_UNKNOWN);
 }
-#line 1483 "grammar.c"
+#line 1487 "grammar.c"
         break;
       case 38: /* edge ::= LEFT_BRACKET COLON UQSTRING properties RIGHT_BRACKET */
 #line 228 "grammar.y"
 { 
 	yymsp[-4].minor.yy93 = New_AST_LinkEntity(NULL, yymsp[-2].minor.yy0.strval, yymsp[-1].minor.yy162, N_DIR_UNKNOWN);
 }
-#line 1490 "grammar.c"
+#line 1494 "grammar.c"
         break;
       case 39: /* edge ::= LEFT_BRACKET UQSTRING COLON UQSTRING properties RIGHT_BRACKET */
 #line 233 "grammar.y"
 { 
 	yymsp[-5].minor.yy93 = New_AST_LinkEntity(yymsp[-4].minor.yy0.strval, yymsp[-2].minor.yy0.strval, yymsp[-1].minor.yy162, N_DIR_UNKNOWN);
 }
-#line 1497 "grammar.c"
+#line 1501 "grammar.c"
         break;
       case 40: /* properties ::= */
 #line 239 "grammar.y"
 {
 	yymsp[1].minor.yy162 = NULL;
 }
-#line 1504 "grammar.c"
+#line 1508 "grammar.c"
         break;
       case 41: /* properties ::= LEFT_CURLY_BRACKET mapLiteral RIGHT_CURLY_BRACKET */
 #line 243 "grammar.y"
 {
 	yymsp[-2].minor.yy162 = yymsp[-1].minor.yy162;
 }
-#line 1511 "grammar.c"
+#line 1515 "grammar.c"
         break;
       case 42: /* mapLiteral ::= UQSTRING COLON value */
 #line 249 "grammar.y"
@@ -1522,7 +1526,7 @@ static void yy_reduce(
 	*val = yymsp[0].minor.yy78;
 	Vector_Push(yylhsminor.yy162, val);
 }
-#line 1526 "grammar.c"
+#line 1530 "grammar.c"
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
       case 43: /* mapLiteral ::= UQSTRING COLON value COMMA mapLiteral */
@@ -1538,7 +1542,7 @@ static void yy_reduce(
 	
 	yylhsminor.yy162 = yymsp[0].minor.yy162;
 }
-#line 1542 "grammar.c"
+#line 1546 "grammar.c"
   yymsp[-4].minor.yy162 = yylhsminor.yy162;
         break;
       case 44: /* whereClause ::= */
@@ -1546,249 +1550,243 @@ static void yy_reduce(
 { 
 	yymsp[1].minor.yy99 = NULL;
 }
-#line 1550 "grammar.c"
+#line 1554 "grammar.c"
         break;
       case 45: /* whereClause ::= WHERE cond */
 #line 278 "grammar.y"
 {
 	yymsp[-1].minor.yy99 = New_AST_WhereNode(yymsp[0].minor.yy130);
 }
-#line 1557 "grammar.c"
+#line 1561 "grammar.c"
         break;
-      case 46: /* cond ::= UQSTRING DOT UQSTRING relation UQSTRING DOT UQSTRING */
-#line 287 "grammar.y"
-{ yylhsminor.yy130 = New_AST_VaryingPredicateNode(yymsp[-6].minor.yy0.strval, yymsp[-4].minor.yy0.strval, yymsp[-3].minor.yy4, yymsp[-2].minor.yy0.strval, yymsp[0].minor.yy0.strval); }
-#line 1562 "grammar.c"
-  yymsp[-6].minor.yy130 = yylhsminor.yy130;
-        break;
-      case 47: /* cond ::= UQSTRING DOT UQSTRING relation value */
-#line 290 "grammar.y"
-{ yylhsminor.yy130 = New_AST_ConstantPredicateNode(yymsp[-4].minor.yy0.strval, yymsp[-2].minor.yy0.strval, yymsp[-1].minor.yy4, yymsp[0].minor.yy78); }
-#line 1568 "grammar.c"
-  yymsp[-4].minor.yy130 = yylhsminor.yy130;
-        break;
-      case 48: /* cond ::= LEFT_PARENTHESIS cond RIGHT_PARENTHESIS */
-#line 291 "grammar.y"
-{ yymsp[-2].minor.yy130 = yymsp[-1].minor.yy130; }
-#line 1574 "grammar.c"
-        break;
-      case 49: /* cond ::= cond AND cond */
+      case 46: /* cond ::= arithmetic_expression relation arithmetic_expression */
 #line 292 "grammar.y"
+{ yylhsminor.yy130 = New_AST_PredicateNode(yymsp[-2].minor.yy58, yymsp[-1].minor.yy4, yymsp[0].minor.yy58); }
+#line 1566 "grammar.c"
+  yymsp[-2].minor.yy130 = yylhsminor.yy130;
+        break;
+      case 47: /* cond ::= LEFT_PARENTHESIS cond RIGHT_PARENTHESIS */
+#line 294 "grammar.y"
+{ yymsp[-2].minor.yy130 = yymsp[-1].minor.yy130; }
+#line 1572 "grammar.c"
+        break;
+      case 48: /* cond ::= cond AND cond */
+#line 295 "grammar.y"
 { yylhsminor.yy130 = New_AST_ConditionNode(yymsp[-2].minor.yy130, AND, yymsp[0].minor.yy130); }
-#line 1579 "grammar.c"
+#line 1577 "grammar.c"
   yymsp[-2].minor.yy130 = yylhsminor.yy130;
         break;
-      case 50: /* cond ::= cond OR cond */
-#line 293 "grammar.y"
+      case 49: /* cond ::= cond OR cond */
+#line 296 "grammar.y"
 { yylhsminor.yy130 = New_AST_ConditionNode(yymsp[-2].minor.yy130, OR, yymsp[0].minor.yy130); }
-#line 1585 "grammar.c"
+#line 1583 "grammar.c"
   yymsp[-2].minor.yy130 = yylhsminor.yy130;
         break;
-      case 51: /* returnClause ::= RETURN returnElements */
-#line 298 "grammar.y"
+      case 50: /* returnClause ::= RETURN returnElements */
+#line 300 "grammar.y"
 {
 	yymsp[-1].minor.yy120 = New_AST_ReturnNode(yymsp[0].minor.yy162, 0);
 }
-#line 1593 "grammar.c"
+#line 1591 "grammar.c"
         break;
-      case 52: /* returnClause ::= RETURN DISTINCT returnElements */
-#line 301 "grammar.y"
+      case 51: /* returnClause ::= RETURN DISTINCT returnElements */
+#line 303 "grammar.y"
 {
 	yymsp[-2].minor.yy120 = New_AST_ReturnNode(yymsp[0].minor.yy162, 1);
 }
-#line 1600 "grammar.c"
+#line 1598 "grammar.c"
         break;
-      case 53: /* returnElements ::= returnElements COMMA returnElement */
-#line 308 "grammar.y"
+      case 52: /* returnElements ::= returnElements COMMA returnElement */
+#line 310 "grammar.y"
 {
 	Vector_Push(yymsp[-2].minor.yy162, yymsp[0].minor.yy163);
 	yylhsminor.yy162 = yymsp[-2].minor.yy162;
 }
-#line 1608 "grammar.c"
+#line 1606 "grammar.c"
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
-      case 54: /* returnElements ::= returnElement */
-#line 313 "grammar.y"
+      case 53: /* returnElements ::= returnElement */
+#line 315 "grammar.y"
 {
 	yylhsminor.yy162 = NewVector(AST_ReturnElementNode*, 1);
 	Vector_Push(yylhsminor.yy162, yymsp[0].minor.yy163);
 }
-#line 1617 "grammar.c"
+#line 1615 "grammar.c"
   yymsp[0].minor.yy162 = yylhsminor.yy162;
         break;
-      case 55: /* returnElement ::= arithmetic_expression */
-#line 320 "grammar.y"
+      case 54: /* returnElement ::= arithmetic_expression */
+#line 322 "grammar.y"
 {
 	yylhsminor.yy163 = New_AST_ReturnElementNode(yymsp[0].minor.yy58, NULL);
 }
-#line 1625 "grammar.c"
+#line 1623 "grammar.c"
   yymsp[0].minor.yy163 = yylhsminor.yy163;
         break;
-      case 56: /* returnElement ::= arithmetic_expression AS UQSTRING */
-#line 325 "grammar.y"
+      case 55: /* returnElement ::= arithmetic_expression AS UQSTRING */
+#line 327 "grammar.y"
 {
 	yylhsminor.yy163 = New_AST_ReturnElementNode(yymsp[-2].minor.yy58, yymsp[0].minor.yy0.strval);
 }
-#line 1633 "grammar.c"
+#line 1631 "grammar.c"
   yymsp[-2].minor.yy163 = yylhsminor.yy163;
         break;
-      case 57: /* arithmetic_expression ::= LEFT_PARENTHESIS arithmetic_expression RIGHT_PARENTHESIS */
-#line 332 "grammar.y"
+      case 56: /* arithmetic_expression ::= LEFT_PARENTHESIS arithmetic_expression RIGHT_PARENTHESIS */
+#line 334 "grammar.y"
 {
 	yymsp[-2].minor.yy58 = yymsp[-1].minor.yy58;
 }
-#line 1641 "grammar.c"
+#line 1639 "grammar.c"
         break;
-      case 58: /* arithmetic_expression ::= arithmetic_expression ADD arithmetic_expression */
-#line 344 "grammar.y"
+      case 57: /* arithmetic_expression ::= arithmetic_expression ADD arithmetic_expression */
+#line 346 "grammar.y"
 {
 	Vector *args = NewVector(AST_ArithmeticExpressionNode*, 2);
 	Vector_Push(args, yymsp[-2].minor.yy58);
 	Vector_Push(args, yymsp[0].minor.yy58);
 	yylhsminor.yy58 = New_AST_AR_EXP_OpNode("ADD", args);
 }
-#line 1651 "grammar.c"
+#line 1649 "grammar.c"
   yymsp[-2].minor.yy58 = yylhsminor.yy58;
         break;
-      case 59: /* arithmetic_expression ::= arithmetic_expression DASH arithmetic_expression */
-#line 351 "grammar.y"
+      case 58: /* arithmetic_expression ::= arithmetic_expression DASH arithmetic_expression */
+#line 353 "grammar.y"
 {
 	Vector *args = NewVector(AST_ArithmeticExpressionNode*, 2);
 	Vector_Push(args, yymsp[-2].minor.yy58);
 	Vector_Push(args, yymsp[0].minor.yy58);
 	yylhsminor.yy58 = New_AST_AR_EXP_OpNode("SUB", args);
 }
-#line 1662 "grammar.c"
+#line 1660 "grammar.c"
   yymsp[-2].minor.yy58 = yylhsminor.yy58;
         break;
-      case 60: /* arithmetic_expression ::= arithmetic_expression MUL arithmetic_expression */
-#line 358 "grammar.y"
+      case 59: /* arithmetic_expression ::= arithmetic_expression MUL arithmetic_expression */
+#line 360 "grammar.y"
 {
 	Vector *args = NewVector(AST_ArithmeticExpressionNode*, 2);
 	Vector_Push(args, yymsp[-2].minor.yy58);
 	Vector_Push(args, yymsp[0].minor.yy58);
 	yylhsminor.yy58 = New_AST_AR_EXP_OpNode("MUL", args);
 }
-#line 1673 "grammar.c"
+#line 1671 "grammar.c"
   yymsp[-2].minor.yy58 = yylhsminor.yy58;
         break;
-      case 61: /* arithmetic_expression ::= arithmetic_expression DIV arithmetic_expression */
-#line 365 "grammar.y"
+      case 60: /* arithmetic_expression ::= arithmetic_expression DIV arithmetic_expression */
+#line 367 "grammar.y"
 {
 	Vector *args = NewVector(AST_ArithmeticExpressionNode*, 2);
 	Vector_Push(args, yymsp[-2].minor.yy58);
 	Vector_Push(args, yymsp[0].minor.yy58);
 	yylhsminor.yy58 = New_AST_AR_EXP_OpNode("DIV", args);
 }
-#line 1684 "grammar.c"
+#line 1682 "grammar.c"
   yymsp[-2].minor.yy58 = yylhsminor.yy58;
         break;
-      case 62: /* arithmetic_expression ::= UQSTRING LEFT_PARENTHESIS arithmetic_expression_list RIGHT_PARENTHESIS */
-#line 373 "grammar.y"
+      case 61: /* arithmetic_expression ::= UQSTRING LEFT_PARENTHESIS arithmetic_expression_list RIGHT_PARENTHESIS */
+#line 375 "grammar.y"
 {
 	yylhsminor.yy58 = New_AST_AR_EXP_OpNode(yymsp[-3].minor.yy0.strval, yymsp[-1].minor.yy162);
 }
-#line 1692 "grammar.c"
+#line 1690 "grammar.c"
   yymsp[-3].minor.yy58 = yylhsminor.yy58;
         break;
-      case 63: /* arithmetic_expression ::= value */
-#line 378 "grammar.y"
+      case 62: /* arithmetic_expression ::= value */
+#line 380 "grammar.y"
 {
 	yylhsminor.yy58 = New_AST_AR_EXP_ConstOperandNode(yymsp[0].minor.yy78);
 }
-#line 1700 "grammar.c"
+#line 1698 "grammar.c"
   yymsp[0].minor.yy58 = yylhsminor.yy58;
         break;
-      case 64: /* arithmetic_expression ::= variable */
-#line 383 "grammar.y"
+      case 63: /* arithmetic_expression ::= variable */
+#line 385 "grammar.y"
 {
 	yylhsminor.yy58 = New_AST_AR_EXP_VariableOperandNode(yymsp[0].minor.yy36->alias, yymsp[0].minor.yy36->property);
 }
-#line 1708 "grammar.c"
+#line 1706 "grammar.c"
   yymsp[0].minor.yy58 = yylhsminor.yy58;
         break;
-      case 65: /* arithmetic_expression_list ::= arithmetic_expression_list COMMA arithmetic_expression */
-#line 389 "grammar.y"
+      case 64: /* arithmetic_expression_list ::= arithmetic_expression_list COMMA arithmetic_expression */
+#line 391 "grammar.y"
 {
 	Vector_Push(yymsp[-2].minor.yy162, yymsp[0].minor.yy58);
 	yylhsminor.yy162 = yymsp[-2].minor.yy162;
 }
-#line 1717 "grammar.c"
+#line 1715 "grammar.c"
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
-      case 66: /* arithmetic_expression_list ::= arithmetic_expression */
-#line 393 "grammar.y"
+      case 65: /* arithmetic_expression_list ::= arithmetic_expression */
+#line 395 "grammar.y"
 {
 	yylhsminor.yy162 = NewVector(AST_ArithmeticExpressionNode*, 1);
 	Vector_Push(yylhsminor.yy162, yymsp[0].minor.yy58);
 }
-#line 1726 "grammar.c"
+#line 1724 "grammar.c"
   yymsp[0].minor.yy162 = yylhsminor.yy162;
         break;
-      case 67: /* variable ::= UQSTRING */
-#line 400 "grammar.y"
+      case 66: /* variable ::= UQSTRING */
+#line 402 "grammar.y"
 {
 	yylhsminor.yy36 = New_AST_Variable(yymsp[0].minor.yy0.strval, NULL);
 }
-#line 1734 "grammar.c"
+#line 1732 "grammar.c"
   yymsp[0].minor.yy36 = yylhsminor.yy36;
         break;
-      case 68: /* variable ::= UQSTRING DOT UQSTRING */
-#line 404 "grammar.y"
+      case 67: /* variable ::= UQSTRING DOT UQSTRING */
+#line 406 "grammar.y"
 {
 	yylhsminor.yy36 = New_AST_Variable(yymsp[-2].minor.yy0.strval, yymsp[0].minor.yy0.strval);
 }
-#line 1742 "grammar.c"
+#line 1740 "grammar.c"
   yymsp[-2].minor.yy36 = yylhsminor.yy36;
         break;
-      case 69: /* orderClause ::= */
-#line 410 "grammar.y"
+      case 68: /* orderClause ::= */
+#line 412 "grammar.y"
 {
 	yymsp[1].minor.yy29 = NULL;
 }
-#line 1750 "grammar.c"
+#line 1748 "grammar.c"
         break;
-      case 70: /* orderClause ::= ORDER BY columnNameList */
-#line 413 "grammar.y"
+      case 69: /* orderClause ::= ORDER BY columnNameList */
+#line 415 "grammar.y"
 {
 	yymsp[-2].minor.yy29 = New_AST_OrderNode(yymsp[0].minor.yy162, ORDER_DIR_ASC);
 }
-#line 1757 "grammar.c"
+#line 1755 "grammar.c"
         break;
-      case 71: /* orderClause ::= ORDER BY columnNameList ASC */
-#line 416 "grammar.y"
+      case 70: /* orderClause ::= ORDER BY columnNameList ASC */
+#line 418 "grammar.y"
 {
 	yymsp[-3].minor.yy29 = New_AST_OrderNode(yymsp[-1].minor.yy162, ORDER_DIR_ASC);
 }
-#line 1764 "grammar.c"
+#line 1762 "grammar.c"
         break;
-      case 72: /* orderClause ::= ORDER BY columnNameList DESC */
-#line 419 "grammar.y"
+      case 71: /* orderClause ::= ORDER BY columnNameList DESC */
+#line 421 "grammar.y"
 {
 	yymsp[-3].minor.yy29 = New_AST_OrderNode(yymsp[-1].minor.yy162, ORDER_DIR_DESC);
 }
-#line 1771 "grammar.c"
+#line 1769 "grammar.c"
         break;
-      case 73: /* columnNameList ::= columnNameList COMMA columnName */
-#line 424 "grammar.y"
+      case 72: /* columnNameList ::= columnNameList COMMA columnName */
+#line 426 "grammar.y"
 {
 	Vector_Push(yymsp[-2].minor.yy162, yymsp[0].minor.yy22);
 	yylhsminor.yy162 = yymsp[-2].minor.yy162;
 }
-#line 1779 "grammar.c"
+#line 1777 "grammar.c"
   yymsp[-2].minor.yy162 = yylhsminor.yy162;
         break;
-      case 74: /* columnNameList ::= columnName */
-#line 428 "grammar.y"
+      case 73: /* columnNameList ::= columnName */
+#line 430 "grammar.y"
 {
 	yylhsminor.yy162 = NewVector(AST_ColumnNode*, 1);
 	Vector_Push(yylhsminor.yy162, yymsp[0].minor.yy22);
 }
-#line 1788 "grammar.c"
+#line 1786 "grammar.c"
   yymsp[0].minor.yy162 = yylhsminor.yy162;
         break;
-      case 75: /* columnName ::= variable */
-#line 434 "grammar.y"
+      case 74: /* columnName ::= variable */
+#line 436 "grammar.y"
 {
 	if(yymsp[0].minor.yy36->property != NULL) {
 		yylhsminor.yy22 = AST_ColumnNodeFromVariable(yymsp[0].minor.yy36);
@@ -1798,95 +1796,95 @@ static void yy_reduce(
 
 	Free_AST_Variable(yymsp[0].minor.yy36);
 }
-#line 1802 "grammar.c"
+#line 1800 "grammar.c"
   yymsp[0].minor.yy22 = yylhsminor.yy22;
         break;
-      case 76: /* limitClause ::= */
-#line 446 "grammar.y"
+      case 75: /* limitClause ::= */
+#line 448 "grammar.y"
 {
 	yymsp[1].minor.yy135 = NULL;
 }
-#line 1810 "grammar.c"
+#line 1808 "grammar.c"
         break;
-      case 77: /* limitClause ::= LIMIT INTEGER */
-#line 449 "grammar.y"
+      case 76: /* limitClause ::= LIMIT INTEGER */
+#line 451 "grammar.y"
 {
 	yymsp[-1].minor.yy135 = New_AST_LimitNode(yymsp[0].minor.yy0.intval);
 }
-#line 1817 "grammar.c"
+#line 1815 "grammar.c"
         break;
-      case 78: /* relation ::= EQ */
-#line 455 "grammar.y"
-{ yymsp[0].minor.yy4 = EQ; }
-#line 1822 "grammar.c"
-        break;
-      case 79: /* relation ::= GT */
-#line 456 "grammar.y"
-{ yymsp[0].minor.yy4 = GT; }
-#line 1827 "grammar.c"
-        break;
-      case 80: /* relation ::= LT */
+      case 77: /* relation ::= EQ */
 #line 457 "grammar.y"
-{ yymsp[0].minor.yy4 = LT; }
-#line 1832 "grammar.c"
+{ yymsp[0].minor.yy4 = EQ; }
+#line 1820 "grammar.c"
         break;
-      case 81: /* relation ::= LE */
+      case 78: /* relation ::= GT */
 #line 458 "grammar.y"
-{ yymsp[0].minor.yy4 = LE; }
-#line 1837 "grammar.c"
+{ yymsp[0].minor.yy4 = GT; }
+#line 1825 "grammar.c"
         break;
-      case 82: /* relation ::= GE */
+      case 79: /* relation ::= LT */
 #line 459 "grammar.y"
-{ yymsp[0].minor.yy4 = GE; }
-#line 1842 "grammar.c"
+{ yymsp[0].minor.yy4 = LT; }
+#line 1830 "grammar.c"
         break;
-      case 83: /* relation ::= NE */
+      case 80: /* relation ::= LE */
 #line 460 "grammar.y"
+{ yymsp[0].minor.yy4 = LE; }
+#line 1835 "grammar.c"
+        break;
+      case 81: /* relation ::= GE */
+#line 461 "grammar.y"
+{ yymsp[0].minor.yy4 = GE; }
+#line 1840 "grammar.c"
+        break;
+      case 82: /* relation ::= NE */
+#line 462 "grammar.y"
 { yymsp[0].minor.yy4 = NE; }
-#line 1847 "grammar.c"
+#line 1845 "grammar.c"
         break;
-      case 84: /* value ::= INTEGER */
-#line 471 "grammar.y"
-{  yylhsminor.yy78 = SI_DoubleVal(yymsp[0].minor.yy0.intval); }
-#line 1852 "grammar.c"
-  yymsp[0].minor.yy78 = yylhsminor.yy78;
-        break;
-      case 85: /* value ::= DASH INTEGER */
-#line 472 "grammar.y"
-{  yymsp[-1].minor.yy78 = SI_DoubleVal(-yymsp[0].minor.yy0.intval); }
-#line 1858 "grammar.c"
-        break;
-      case 86: /* value ::= STRING */
+      case 83: /* value ::= INTEGER */
 #line 473 "grammar.y"
-{  yylhsminor.yy78 = SI_StringVal(yymsp[0].minor.yy0.strval); }
-#line 1863 "grammar.c"
+{  yylhsminor.yy78 = SI_DoubleVal(yymsp[0].minor.yy0.intval); }
+#line 1850 "grammar.c"
   yymsp[0].minor.yy78 = yylhsminor.yy78;
         break;
-      case 87: /* value ::= FLOAT */
+      case 84: /* value ::= DASH INTEGER */
 #line 474 "grammar.y"
-{  yylhsminor.yy78 = SI_DoubleVal(yymsp[0].minor.yy0.dval); }
-#line 1869 "grammar.c"
+{  yymsp[-1].minor.yy78 = SI_DoubleVal(-yymsp[0].minor.yy0.intval); }
+#line 1856 "grammar.c"
+        break;
+      case 85: /* value ::= STRING */
+#line 475 "grammar.y"
+{  yylhsminor.yy78 = SI_StringVal(yymsp[0].minor.yy0.strval); }
+#line 1861 "grammar.c"
   yymsp[0].minor.yy78 = yylhsminor.yy78;
         break;
-      case 88: /* value ::= DASH FLOAT */
-#line 475 "grammar.y"
-{  yymsp[-1].minor.yy78 = SI_DoubleVal(-yymsp[0].minor.yy0.dval); }
-#line 1875 "grammar.c"
-        break;
-      case 89: /* value ::= TRUE */
+      case 86: /* value ::= FLOAT */
 #line 476 "grammar.y"
-{ yymsp[0].minor.yy78 = SI_BoolVal(1); }
-#line 1880 "grammar.c"
+{  yylhsminor.yy78 = SI_DoubleVal(yymsp[0].minor.yy0.dval); }
+#line 1867 "grammar.c"
+  yymsp[0].minor.yy78 = yylhsminor.yy78;
         break;
-      case 90: /* value ::= FALSE */
+      case 87: /* value ::= DASH FLOAT */
 #line 477 "grammar.y"
-{ yymsp[0].minor.yy78 = SI_BoolVal(0); }
-#line 1885 "grammar.c"
+{  yymsp[-1].minor.yy78 = SI_DoubleVal(-yymsp[0].minor.yy0.dval); }
+#line 1873 "grammar.c"
         break;
-      case 91: /* value ::= NULLVAL */
+      case 88: /* value ::= TRUE */
 #line 478 "grammar.y"
+{ yymsp[0].minor.yy78 = SI_BoolVal(1); }
+#line 1878 "grammar.c"
+        break;
+      case 89: /* value ::= FALSE */
+#line 479 "grammar.y"
+{ yymsp[0].minor.yy78 = SI_BoolVal(0); }
+#line 1883 "grammar.c"
+        break;
+      case 90: /* value ::= NULLVAL */
+#line 480 "grammar.y"
 { yymsp[0].minor.yy78 = SI_NullVal(); }
-#line 1890 "grammar.c"
+#line 1888 "grammar.c"
         break;
       default:
         break;
@@ -1951,7 +1949,7 @@ static void yy_syntax_error(
 
 	ctx->ok = 0;
 	ctx->errorMsg = strdup(buf);
-#line 1955 "grammar.c"
+#line 1953 "grammar.c"
 /************ End %syntax_error code ******************************************/
   ParseARG_STORE; /* Suppress warning about unused %extra_argument variable */
 }
@@ -2165,7 +2163,7 @@ void Parse(
 #endif
   return;
 }
-#line 480 "grammar.y"
+#line 482 "grammar.y"
 
 
 	/* Definitions of flex stuff */
@@ -2197,4 +2195,4 @@ void Parse(
 		}
 		return ctx.root;
 	}
-#line 2201 "grammar.c"
+#line 2199 "grammar.c"

--- a/src/parser/grammar.h
+++ b/src/parser/grammar.h
@@ -29,10 +29,10 @@
 #define LEFT_CURLY_BRACKET              29
 #define RIGHT_CURLY_BRACKET             30
 #define WHERE                           31
-#define DOT                             32
-#define RETURN                          33
-#define DISTINCT                        34
-#define AS                              35
+#define RETURN                          32
+#define DISTINCT                        33
+#define AS                              34
+#define DOT                             35
 #define ORDER                           36
 #define BY                              37
 #define ASC                             38

--- a/src/parser/grammar.y
+++ b/src/parser/grammar.y
@@ -284,14 +284,16 @@ whereClause(A) ::= WHERE cond(B). {
 %destructor cond { Free_AST_FilterNode($$); }
 
 // me.age > friend.age
-cond(A) ::= UQSTRING(B) DOT UQSTRING(C) relation(D) UQSTRING(E) DOT UQSTRING(F). { A = New_AST_VaryingPredicateNode(B.strval, C.strval, D, E.strval, F.strval); }
+/* cond(A) ::= UQSTRING(B) DOT UQSTRING(C) relation(D) UQSTRING(E) DOT UQSTRING(F). { A = New_AST_VaryingPredicateNode(B.strval, C.strval, D, E.strval, F.strval); } */
 // me.age > 30
 // TODO: change value to arithmetic_expression.
-cond(A) ::= UQSTRING(B) DOT UQSTRING(C) relation(D) value(E). { A = New_AST_ConstantPredicateNode(B.strval, C.strval, D, E); }
+/* cond(A) ::= UQSTRING(B) DOT UQSTRING(C) relation(D) value(E). { A = New_AST_ConstantPredicateNode(B.strval, C.strval, D, E); } */
+// arithmetic expression
+cond(A) ::= arithmetic_expression(B) relation(C) arithmetic_expression(D). { A = New_AST_PredicateNode(B, C, D); }
+
 cond(A) ::= LEFT_PARENTHESIS cond(B) RIGHT_PARENTHESIS. { A = B; }
 cond(A) ::= cond(B) AND cond(C). { A = New_AST_ConditionNode(B, AND, C); }
 cond(A) ::= cond(B) OR cond(C). { A = New_AST_ConditionNode(B, OR, C); }
-
 
 %type returnClause {AST_ReturnNode*}
 

--- a/src/parser/grammar.y
+++ b/src/parser/grammar.y
@@ -283,12 +283,7 @@ whereClause(A) ::= WHERE cond(B). {
 %type cond {AST_FilterNode*}
 %destructor cond { Free_AST_FilterNode($$); }
 
-// me.age > friend.age
-/* cond(A) ::= UQSTRING(B) DOT UQSTRING(C) relation(D) UQSTRING(E) DOT UQSTRING(F). { A = New_AST_VaryingPredicateNode(B.strval, C.strval, D, E.strval, F.strval); } */
-// me.age > 30
-// TODO: change value to arithmetic_expression.
-/* cond(A) ::= UQSTRING(B) DOT UQSTRING(C) relation(D) value(E). { A = New_AST_ConstantPredicateNode(B.strval, C.strval, D, E); } */
-// arithmetic expression
+// arithmetic expressions can be constant values, variables, or functions
 cond(A) ::= arithmetic_expression(B) relation(C) arithmetic_expression(D). { A = New_AST_PredicateNode(B, C, D); }
 
 cond(A) ::= LEFT_PARENTHESIS cond(B) RIGHT_PARENTHESIS. { A = B; }

--- a/src/parser/lex.yy.c
+++ b/src/parser/lex.yy.c
@@ -8,7 +8,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -83,60 +83,48 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -166,14 +154,14 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -190,7 +178,6 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -205,7 +192,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -233,7 +220,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -261,7 +248,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -272,7 +259,6 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -281,10 +267,10 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
 static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
@@ -293,62 +279,56 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void yyensure_buffer_stack (void );
-static void yy_load_buffer_state (void );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
-
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *yyin = (FILE *) 0, *yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
 extern int yylineno;
-
 int yylineno = 1;
 
 extern char *yytext;
@@ -357,24 +337,20 @@ extern char *yytext;
 #endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 50
 #define YY_END_OF_BUFFER 51
 /* This struct is not used in this scanner,
@@ -384,7 +360,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[133] =
+static const flex_int16_t yy_accept[133] =
     {   0,
         0,    0,   51,   50,   48,   49,   50,   50,   50,   28,
        29,   46,   47,   27,   42,   44,   45,   24,   43,   41,
@@ -403,7 +379,7 @@ static yyconst flex_int16_t yy_accept[133] =
        11,    0
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -435,7 +411,7 @@ static yyconst YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[68] =
+static const YY_CHAR yy_meta[68] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    2,    1,    1,    2,    1,    1,    1,    1,    2,
@@ -446,7 +422,7 @@ static yyconst YY_CHAR yy_meta[68] =
         2,    2,    2,    2,    2,    1,    1
     } ;
 
-static yyconst flex_uint16_t yy_base[138] =
+static const flex_int16_t yy_base[138] =
     {   0,
         0,    0,  242,  265,  239,  265,  219,   63,   64,  265,
       265,  265,  265,  265,  217,  219,  265,   56,  265,   60,
@@ -465,7 +441,7 @@ static yyconst flex_uint16_t yy_base[138] =
         0,  265,  256,  258,   80,  260,  262
     } ;
 
-static yyconst flex_int16_t yy_def[138] =
+static const flex_int16_t yy_def[138] =
     {   0,
       132,    1,  132,  132,  132,  132,  132,  133,  134,  132,
       132,  132,  132,  132,  132,  132,  132,  132,  132,  132,
@@ -484,7 +460,7 @@ static yyconst flex_int16_t yy_def[138] =
       135,    0,  132,  132,  132,  132,  132
     } ;
 
-static yyconst flex_uint16_t yy_nxt[333] =
+static const flex_int16_t yy_nxt[333] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
        14,   15,   16,   17,   18,   19,   20,   21,   22,   23,
@@ -525,7 +501,7 @@ static yyconst flex_uint16_t yy_nxt[333] =
       132,  132
     } ;
 
-static yyconst flex_int16_t yy_chk[333] =
+static const flex_int16_t yy_chk[333] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -597,7 +573,8 @@ int yycolumn = 1;
 #define YY_USER_ACTION yycolumn += yyleng; \
     tok.pos = yycolumn; \
     tok.s = strdup(yytext);
-#line 601 "lex.yy.c"
+#line 577 "lex.yy.c"
+#line 578 "lex.yy.c"
 
 #define INITIAL 0
 
@@ -613,36 +590,36 @@ int yycolumn = 1;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * _in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * _out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int _line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -650,32 +627,31 @@ void yyset_lineno (int _line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput (int c,char *buf_ptr  );
+    static void yyunput ( int c, char *buf_ptr  );
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
@@ -695,7 +671,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -706,7 +682,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -719,7 +695,7 @@ static int input (void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -808,17 +784,17 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
 	{
 #line 19 "lexer.l"
 
 
-#line 822 "lex.yy.c"
+#line 798 "lex.yy.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -846,9 +822,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 133 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 265 );
@@ -1141,7 +1117,7 @@ YY_RULE_SETUP
 #line 92 "lexer.l"
 ECHO;
 	YY_BREAK
-#line 1145 "lex.yy.c"
+#line 1121 "lex.yy.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1219,7 +1195,7 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1286,7 +1262,7 @@ static int yy_get_next_buffer (void)
 {
     	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = (yytext_ptr);
-	yy_size_t number_to_move, i;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1315,7 +1291,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (yy_size_t) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1328,7 +1304,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1342,7 +1318,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1351,11 +1327,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1383,7 +1360,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1397,12 +1374,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1435,9 +1415,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 133 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1463,9 +1443,9 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 133 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 132);
 
 		return yy_is_jam ? 0 : yy_current_state;
@@ -1485,7 +1465,7 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		yy_size_t number_to_move = (yy_n_chars) + 2;
+		int number_to_move = (yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -1497,7 +1477,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -1536,7 +1516,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1553,14 +1533,14 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( ) )
-						return EOF;
+					if ( yywrap(  ) )
+						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -1597,11 +1577,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
@@ -1629,7 +1609,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -1657,22 +1637,22 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = (yy_size_t)size;
+	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
@@ -1691,9 +1671,9 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
@@ -1705,7 +1685,7 @@ static void yy_load_buffer_state  (void)
 {
 	int oerrno = errno;
     
-	yy_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1748,7 +1728,7 @@ static void yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -1779,7 +1759,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -1798,7 +1778,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -1816,15 +1796,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -1853,7 +1833,7 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
@@ -1863,23 +1843,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
@@ -1892,10 +1872,10 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return yy_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
@@ -1905,16 +1885,16 @@ YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -1923,7 +1903,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -1939,9 +1919,9 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-			(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -1969,7 +1949,7 @@ static void yy_fatal_error (yyconst char* msg )
  */
 int yyget_lineno  (void)
 {
-        
+    
     return yylineno;
 }
 
@@ -1992,7 +1972,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t yyget_leng  (void)
+int yyget_leng  (void)
 {
         return yyleng;
 }
@@ -2048,10 +2028,10 @@ static int yy_init_globals (void)
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -2060,8 +2040,8 @@ static int yy_init_globals (void)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2076,7 +2056,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -2097,7 +2077,7 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
 		
 	int i;
@@ -2107,7 +2087,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -2119,7 +2099,7 @@ static int yy_flex_strlen (yyconst char * s )
 
 void *yyalloc (yy_size_t  size )
 {
-			return (void *) malloc( size );
+			return malloc(size);
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
@@ -2132,7 +2112,7 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yyfree (void * ptr )
@@ -2143,7 +2123,6 @@ void yyfree (void * ptr )
 #define YYTABLES_NAME "yytables"
 
 #line 92 "lexer.l"
-
 
 
 /**

--- a/src/parser/lex.yy.c
+++ b/src/parser/lex.yy.c
@@ -7,8 +7,8 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -46,7 +46,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -54,7 +53,6 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -85,63 +83,61 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
+#endif /* ! C99 */
+
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -158,15 +154,16 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
+    #define YY_LINENO_REWIND_TO(ptr)
     
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
@@ -181,7 +178,6 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -196,12 +192,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -224,7 +220,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -252,7 +248,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -263,7 +259,6 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -271,11 +266,11 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
@@ -284,82 +279,78 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void yyensure_buffer_stack (void );
-static void yy_load_buffer_state (void );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
-
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *yyin = (FILE *) 0, *yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
 extern int yylineno;
-
 int yylineno = 1;
 
 extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (yy_size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 50
 #define YY_END_OF_BUFFER 51
 /* This struct is not used in this scanner,
@@ -369,7 +360,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[133] =
+static const flex_int16_t yy_accept[133] =
     {   0,
         0,    0,   51,   50,   48,   49,   50,   50,   50,   28,
        29,   46,   47,   27,   42,   44,   45,   24,   43,   41,
@@ -388,7 +379,7 @@ static yyconst flex_int16_t yy_accept[133] =
        11,    0
     } ;
 
-static yyconst flex_int32_t yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -420,7 +411,7 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int32_t yy_meta[68] =
+static const YY_CHAR yy_meta[68] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    2,    1,    1,    2,    1,    1,    1,    1,    2,
@@ -431,7 +422,7 @@ static yyconst flex_int32_t yy_meta[68] =
         2,    2,    2,    2,    2,    1,    1
     } ;
 
-static yyconst flex_int16_t yy_base[138] =
+static const flex_int16_t yy_base[138] =
     {   0,
         0,    0,  242,  265,  239,  265,  219,   63,   64,  265,
       265,  265,  265,  265,  217,  219,  265,   56,  265,   60,
@@ -450,7 +441,7 @@ static yyconst flex_int16_t yy_base[138] =
         0,  265,  256,  258,   80,  260,  262
     } ;
 
-static yyconst flex_int16_t yy_def[138] =
+static const flex_int16_t yy_def[138] =
     {   0,
       132,    1,  132,  132,  132,  132,  132,  133,  134,  132,
       132,  132,  132,  132,  132,  132,  132,  132,  132,  132,
@@ -469,7 +460,7 @@ static yyconst flex_int16_t yy_def[138] =
       135,    0,  132,  132,  132,  132,  132
     } ;
 
-static yyconst flex_int16_t yy_nxt[333] =
+static const flex_int16_t yy_nxt[333] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
        14,   15,   16,   17,   18,   19,   20,   21,   22,   23,
@@ -510,7 +501,7 @@ static yyconst flex_int16_t yy_nxt[333] =
       132,  132
     } ;
 
-static yyconst flex_int16_t yy_chk[333] =
+static const flex_int16_t yy_chk[333] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -582,7 +573,8 @@ int yycolumn = 1;
 #define YY_USER_ACTION yycolumn += yyleng; \
     tok.pos = yycolumn; \
     tok.s = strdup(yytext);
-#line 586 "lex.yy.c"
+#line 577 "lex.yy.c"
+#line 578 "lex.yy.c"
 
 #define INITIAL 0
 
@@ -598,36 +590,36 @@ int yycolumn = 1;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -635,35 +627,43 @@ void yyset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
-    static void yyunput (int c,char *buf_ptr  );
+#ifndef YY_NO_UNPUT
     
+    static void yyunput ( int c, char *buf_ptr  );
+    
+#endif
+
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -671,7 +671,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO fwrite( yytext, yyleng, 1, yyout )
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -682,7 +682,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		yy_size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -695,7 +695,7 @@ static int input (void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -750,7 +750,7 @@ extern int yylex (void);
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK break;
+#define YY_BREAK /*LINTED*/break;
 #endif
 
 #define YY_RULE_SETUP \
@@ -760,15 +760,10 @@ extern int yylex (void);
  */
 YY_DECL
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
     
-#line 19 "lexer.l"
-
-
-#line 771 "lex.yy.c"
-
 	if ( !(yy_init) )
 		{
 		(yy_init) = 1;
@@ -789,13 +784,19 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
-	while ( 1 )		/* loops until end-of-file is reached */
+	{
+#line 19 "lexer.l"
+
+
+#line 798 "lex.yy.c"
+
+	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
@@ -811,7 +812,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
 				(yy_last_accepting_state) = yy_current_state;
@@ -821,9 +822,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 133 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 265 );
@@ -1116,7 +1117,7 @@ YY_RULE_SETUP
 #line 92 "lexer.l"
 ECHO;
 	YY_BREAK
-#line 1120 "lex.yy.c"
+#line 1121 "lex.yy.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1194,7 +1195,7 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1247,6 +1248,7 @@ case YY_STATE_EOF(INITIAL):
 			"fatal flex scanner internal error--no action found" );
 	} /* end of action switch */
 		} /* end of scanning one token */
+	} /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
@@ -1258,9 +1260,9 @@ case YY_STATE_EOF(INITIAL):
  */
 static int yy_get_next_buffer (void)
 {
-    	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	register char *source = (yytext_ptr);
-	register int number_to_move, i;
+    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = (yytext_ptr);
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1289,7 +1291,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1302,21 +1304,21 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
 			{ /* Not enough room in the buffer - grow it. */
 
 			/* just a shorter name for the current buffer */
-			YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
+			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
 
 			int yy_c_buf_p_offset =
 				(int) ((yy_c_buf_p) - b->yy_ch_buf);
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1325,11 +1327,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1357,7 +1360,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1371,12 +1374,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1392,14 +1398,14 @@ static int yy_get_next_buffer (void)
 
     static yy_state_type yy_get_previous_state (void)
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
     
 	yy_current_state = (yy_start);
 
 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			(yy_last_accepting_state) = yy_current_state;
@@ -1409,9 +1415,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 133 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1424,10 +1430,10 @@ static int yy_get_next_buffer (void)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
-	register int yy_is_jam;
-    	register char *yy_cp = (yy_c_buf_p);
+	int yy_is_jam;
+    	char *yy_cp = (yy_c_buf_p);
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		(yy_last_accepting_state) = yy_current_state;
@@ -1437,17 +1443,19 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 133 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 132);
 
-	return yy_is_jam ? 0 : yy_current_state;
+		return yy_is_jam ? 0 : yy_current_state;
 }
 
-    static void yyunput (int c, register char * yy_bp )
+#ifndef YY_NO_UNPUT
+
+    static void yyunput (int c, char * yy_bp )
 {
-	register char *yy_cp;
+	char *yy_cp;
     
     yy_cp = (yy_c_buf_p);
 
@@ -1457,10 +1465,10 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register yy_size_t number_to_move = (yy_n_chars) + 2;
-		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
+		int number_to_move = (yy_n_chars) + 2;
+		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
 
 		while ( source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -1469,7 +1477,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -1481,6 +1489,8 @@ static int yy_get_next_buffer (void)
 	(yy_hold_char) = *yy_cp;
 	(yy_c_buf_p) = yy_cp;
 }
+
+#endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -1506,7 +1516,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1523,13 +1533,13 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( ) )
+					if ( yywrap(  ) )
 						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
@@ -1567,11 +1577,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
@@ -1599,7 +1609,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -1627,7 +1637,7 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
@@ -1636,13 +1646,13 @@ static void yy_load_buffer_state  (void)
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
@@ -1661,15 +1671,11 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
-#ifndef __cplusplus
-extern int isatty (int );
-#endif /* __cplusplus */
-    
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a yyrestart() or at EOF.
@@ -1679,7 +1685,7 @@ extern int isatty (int );
 {
 	int oerrno = errno;
     
-	yy_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1722,7 +1728,7 @@ extern int isatty (int );
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -1753,7 +1759,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -1772,7 +1778,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -1790,15 +1796,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1;
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -1807,7 +1813,7 @@ static void yyensure_buffer_stack (void)
 	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		int grow_size = 8 /* arbitrary grow size */;
+		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
@@ -1827,7 +1833,7 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
@@ -1837,23 +1843,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
@@ -1866,28 +1872,29 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return yy_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
- * @param bytes the byte buffer to scan
- * @param len the number of bytes in the buffer pointed to by @a bytes.
+ * @param yybytes the byte buffer to scan
+ * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
-	yy_size_t n, i;
+	yy_size_t n;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -1896,7 +1903,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -1912,9 +1919,9 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-    	(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -1942,7 +1949,7 @@ static void yy_fatal_error (yyconst char* msg )
  */
 int yyget_lineno  (void)
 {
-        
+    
     return yylineno;
 }
 
@@ -1965,7 +1972,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t yyget_leng  (void)
+int yyget_leng  (void)
 {
         return yyleng;
 }
@@ -1980,29 +1987,29 @@ char *yyget_text  (void)
 }
 
 /** Set the current line number.
- * @param line_number
+ * @param _line_number line number
  * 
  */
-void yyset_lineno (int  line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    yylineno = line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param in_str A readable stream.
+ * @param _in_str A readable stream.
  * 
  * @see yy_switch_to_buffer
  */
-void yyset_in (FILE *  in_str )
+void yyset_in (FILE *  _in_str )
 {
-        yyin = in_str ;
+        yyin = _in_str ;
 }
 
-void yyset_out (FILE *  out_str )
+void yyset_out (FILE *  _out_str )
 {
-        yyout = out_str ;
+        yyout = _out_str ;
 }
 
 int yyget_debug  (void)
@@ -2010,9 +2017,9 @@ int yyget_debug  (void)
         return yy_flex_debug;
 }
 
-void yyset_debug (int  bdebug )
+void yyset_debug (int  _bdebug )
 {
-        yy_flex_debug = bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
@@ -2021,10 +2028,10 @@ static int yy_init_globals (void)
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -2033,8 +2040,8 @@ static int yy_init_globals (void)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2049,7 +2056,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -2070,18 +2077,19 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
-	register int i;
+		
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 
@@ -2091,11 +2099,12 @@ static int yy_flex_strlen (yyconst char * s )
 
 void *yyalloc (yy_size_t  size )
 {
-	return (void *) malloc( size );
+			return malloc(size);
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
 {
+		
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -2103,18 +2112,17 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yyfree (void * ptr )
 {
-	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
 #line 92 "lexer.l"
-
 
 
 /**

--- a/src/parser/lex.yy.c
+++ b/src/parser/lex.yy.c
@@ -8,7 +8,7 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 4
+#define YY_FLEX_SUBMINOR_VERSION 0
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -83,48 +83,60 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
-#ifndef SIZE_MAX
-#define SIZE_MAX               (~(size_t)0)
-#endif
-
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-/* begin standard C++ headers. */
+#ifdef __cplusplus
 
-/* TODO: this is always defined, so inline it */
+/* The "const" storage-class-modifier is valid. */
+#define YY_USE_CONST
+
+#else	/* ! __cplusplus */
+
+/* C99 requires __STDC__ to be defined as 1. */
+#if defined (__STDC__)
+
+#define YY_USE_CONST
+
+#endif	/* defined (__STDC__) */
+#endif	/* ! __cplusplus */
+
+#ifdef YY_USE_CONST
 #define yyconst const
-
-#if defined(__GNUC__) && __GNUC__ >= 3
-#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yynoreturn
+#define yyconst
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an
- *   integer in range [0..255] for use as an array index.
+/* Promotes a possibly negative, possibly signed char to an unsigned
+ * integer for use as an array index.  If the signed char is negative,
+ * we want to instead treat it as an 8-bit unsigned char, hence the
+ * double cast.
  */
-#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
+#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
+
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
+
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
+
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart( yyin  )
+#define YY_NEW_FILE yyrestart(yyin  )
+
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -154,14 +166,14 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern int yyleng;
+extern yy_size_t yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-    
+
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -178,6 +190,7 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
+
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -192,7 +205,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	int yy_buf_size;
+	yy_size_t yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -220,7 +233,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-
+    
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -248,7 +261,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -259,6 +272,7 @@ static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
+
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -267,10 +281,10 @@ static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
 static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-int yyleng;
+yy_size_t yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = NULL;
+static char *yy_c_buf_p = (char *) 0;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
@@ -279,56 +293,62 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart ( FILE *input_file  );
-void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
-void yy_delete_buffer ( YY_BUFFER_STATE b  );
-void yy_flush_buffer ( YY_BUFFER_STATE b  );
-void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state ( void );
+void yyrestart (FILE *input_file  );
+void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
+void yy_delete_buffer (YY_BUFFER_STATE b  );
+void yy_flush_buffer (YY_BUFFER_STATE b  );
+void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state (void );
 
-static void yyensure_buffer_stack ( void );
-static void yy_load_buffer_state ( void );
-static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
-#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
+static void yyensure_buffer_stack (void );
+static void yy_load_buffer_state (void );
+static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
 
-YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
+#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
 
-void *yyalloc ( yy_size_t  );
-void *yyrealloc ( void *, yy_size_t  );
-void yyfree ( void *  );
+YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
+
+void *yyalloc (yy_size_t  );
+void *yyrealloc (void *,yy_size_t  );
+void yyfree (void *  );
 
 #define yy_new_buffer yy_create_buffer
+
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer( yyin, YY_BUF_SIZE ); \
+            yy_create_buffer(yyin,YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
+
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer( yyin, YY_BUF_SIZE ); \
+            yy_create_buffer(yyin,YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
+
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
-typedef flex_uint8_t YY_CHAR;
 
-FILE *yyin = NULL, *yyout = NULL;
+typedef unsigned char YY_CHAR;
+
+FILE *yyin = (FILE *) 0, *yyout = (FILE *) 0;
 
 typedef int yy_state_type;
 
 extern int yylineno;
+
 int yylineno = 1;
 
 extern char *yytext;
@@ -337,20 +357,24 @@ extern char *yytext;
 #endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state ( void );
-static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
-static int yy_get_next_buffer ( void );
-static void yynoreturn yy_fatal_error ( const char* msg  );
+static yy_state_type yy_get_previous_state (void );
+static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
+static int yy_get_next_buffer (void );
+#if defined(__GNUC__) && __GNUC__ >= 3
+__attribute__((__noreturn__))
+#endif
+static void yy_fatal_error (yyconst char msg[]  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (int) (yy_cp - yy_bp); \
+	yyleng = (size_t) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
+
 #define YY_NUM_RULES 50
 #define YY_END_OF_BUFFER 51
 /* This struct is not used in this scanner,
@@ -360,7 +384,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[133] =
+static yyconst flex_int16_t yy_accept[133] =
     {   0,
         0,    0,   51,   50,   48,   49,   50,   50,   50,   28,
        29,   46,   47,   27,   42,   44,   45,   24,   43,   41,
@@ -379,7 +403,7 @@ static const flex_int16_t yy_accept[133] =
        11,    0
     } ;
 
-static const YY_CHAR yy_ec[256] =
+static yyconst YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -411,7 +435,7 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static const YY_CHAR yy_meta[68] =
+static yyconst YY_CHAR yy_meta[68] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    2,    1,    1,    2,    1,    1,    1,    1,    2,
@@ -422,7 +446,7 @@ static const YY_CHAR yy_meta[68] =
         2,    2,    2,    2,    2,    1,    1
     } ;
 
-static const flex_int16_t yy_base[138] =
+static yyconst flex_uint16_t yy_base[138] =
     {   0,
         0,    0,  242,  265,  239,  265,  219,   63,   64,  265,
       265,  265,  265,  265,  217,  219,  265,   56,  265,   60,
@@ -441,7 +465,7 @@ static const flex_int16_t yy_base[138] =
         0,  265,  256,  258,   80,  260,  262
     } ;
 
-static const flex_int16_t yy_def[138] =
+static yyconst flex_int16_t yy_def[138] =
     {   0,
       132,    1,  132,  132,  132,  132,  132,  133,  134,  132,
       132,  132,  132,  132,  132,  132,  132,  132,  132,  132,
@@ -460,7 +484,7 @@ static const flex_int16_t yy_def[138] =
       135,    0,  132,  132,  132,  132,  132
     } ;
 
-static const flex_int16_t yy_nxt[333] =
+static yyconst flex_uint16_t yy_nxt[333] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
        14,   15,   16,   17,   18,   19,   20,   21,   22,   23,
@@ -501,7 +525,7 @@ static const flex_int16_t yy_nxt[333] =
       132,  132
     } ;
 
-static const flex_int16_t yy_chk[333] =
+static yyconst flex_int16_t yy_chk[333] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -573,8 +597,7 @@ int yycolumn = 1;
 #define YY_USER_ACTION yycolumn += yyleng; \
     tok.pos = yycolumn; \
     tok.s = strdup(yytext);
-#line 577 "lex.yy.c"
-#line 578 "lex.yy.c"
+#line 601 "lex.yy.c"
 
 #define INITIAL 0
 
@@ -590,36 +613,36 @@ int yycolumn = 1;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals ( void );
+static int yy_init_globals (void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy ( void );
+int yylex_destroy (void );
 
-int yyget_debug ( void );
+int yyget_debug (void );
 
-void yyset_debug ( int debug_flag  );
+void yyset_debug (int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra ( void );
+YY_EXTRA_TYPE yyget_extra (void );
 
-void yyset_extra ( YY_EXTRA_TYPE user_defined  );
+void yyset_extra (YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in ( void );
+FILE *yyget_in (void );
 
-void yyset_in  ( FILE * _in_str  );
+void yyset_in  (FILE * _in_str  );
 
-FILE *yyget_out ( void );
+FILE *yyget_out (void );
 
-void yyset_out  ( FILE * _out_str  );
+void yyset_out  (FILE * _out_str  );
 
-			int yyget_leng ( void );
+yy_size_t yyget_leng (void );
 
-char *yyget_text ( void );
+char *yyget_text (void );
 
-int yyget_lineno ( void );
+int yyget_lineno (void );
 
-void yyset_lineno ( int _line_number  );
+void yyset_lineno (int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -627,31 +650,32 @@ void yyset_lineno ( int _line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap ( void );
+extern "C" int yywrap (void );
 #else
-extern int yywrap ( void );
+extern int yywrap (void );
 #endif
 #endif
 
 #ifndef YY_NO_UNPUT
     
-    static void yyunput ( int c, char *buf_ptr  );
+    static void yyunput (int c,char *buf_ptr  );
     
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy ( char *, const char *, int );
+static void yy_flex_strncpy (char *,yyconst char *,int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen ( const char * );
+static int yy_flex_strlen (yyconst char * );
 #endif
 
 #ifndef YY_NO_INPUT
+
 #ifdef __cplusplus
-static int yyinput ( void );
+static int yyinput (void );
 #else
-static int input ( void );
+static int input (void );
 #endif
 
 #endif
@@ -671,7 +695,7 @@ static int input ( void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -682,7 +706,7 @@ static int input ( void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		int n; \
+		size_t n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -695,7 +719,7 @@ static int input ( void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
+		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -784,17 +808,17 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer( yyin, YY_BUF_SIZE );
+				yy_create_buffer(yyin,YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state(  );
+		yy_load_buffer_state( );
 		}
 
 	{
 #line 19 "lexer.l"
 
 
-#line 798 "lex.yy.c"
+#line 822 "lex.yy.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -822,9 +846,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 133 )
-					yy_c = yy_meta[yy_c];
+					yy_c = yy_meta[(unsigned int) yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 265 );
@@ -1117,7 +1141,7 @@ YY_RULE_SETUP
 #line 92 "lexer.l"
 ECHO;
 	YY_BREAK
-#line 1121 "lex.yy.c"
+#line 1145 "lex.yy.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1195,7 +1219,7 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap(  ) )
+				if ( yywrap( ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1262,7 +1286,7 @@ static int yy_get_next_buffer (void)
 {
     	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = (yytext_ptr);
-	int number_to_move, i;
+	yy_size_t number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1291,7 +1315,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
+	number_to_move = (yy_size_t) ((yy_c_buf_p) - (yytext_ptr)) - 1;
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1304,7 +1328,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			int num_to_read =
+			yy_size_t num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1318,7 +1342,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				int new_size = b->yy_buf_size * 2;
+				yy_size_t new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1327,12 +1351,11 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc( (void *) b->yy_ch_buf,
-							 (yy_size_t) (b->yy_buf_size + 2)  );
+					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = NULL;
+				b->yy_ch_buf = 0;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1360,7 +1383,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart( yyin  );
+			yyrestart(yyin  );
 			}
 
 		else
@@ -1374,15 +1397,12 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
-			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
-		/* "- 2" to take care of EOB's */
-		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1415,9 +1435,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 133 )
-				yy_c = yy_meta[yy_c];
+				yy_c = yy_meta[(unsigned int) yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 		}
 
 	return yy_current_state;
@@ -1443,9 +1463,9 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 133 )
-			yy_c = yy_meta[yy_c];
+			yy_c = yy_meta[(unsigned int) yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 	yy_is_jam = (yy_current_state == 132);
 
 		return yy_is_jam ? 0 : yy_current_state;
@@ -1465,7 +1485,7 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		int number_to_move = (yy_n_chars) + 2;
+		yy_size_t number_to_move = (yy_n_chars) + 2;
 		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
 		char *source =
@@ -1477,7 +1497,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -1516,7 +1536,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
+			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1533,14 +1553,14 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart( yyin );
+					yyrestart(yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap(  ) )
-						return 0;
+					if ( yywrap( ) )
+						return EOF;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -1577,11 +1597,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer( yyin, YY_BUF_SIZE );
+            yy_create_buffer(yyin,YY_BUF_SIZE );
 	}
 
-	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
-	yy_load_buffer_state(  );
+	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
+	yy_load_buffer_state( );
 }
 
 /** Switch to a different input buffer.
@@ -1609,7 +1629,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state(  );
+	yy_load_buffer_state( );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -1637,22 +1657,22 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = size;
+	b->yy_buf_size = (yy_size_t)size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
+	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer( b, file );
+	yy_init_buffer(b,file );
 
 	return b;
 }
@@ -1671,9 +1691,9 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree( (void *) b->yy_ch_buf  );
+		yyfree((void *) b->yy_ch_buf  );
 
-	yyfree( (void *) b  );
+	yyfree((void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
@@ -1685,7 +1705,7 @@ static void yy_load_buffer_state  (void)
 {
 	int oerrno = errno;
     
-	yy_flush_buffer( b );
+	yy_flush_buffer(b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1728,7 +1748,7 @@ static void yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state(  );
+		yy_load_buffer_state( );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -1759,7 +1779,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state(  );
+	yy_load_buffer_state( );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -1778,7 +1798,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state(  );
+		yy_load_buffer_state( );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -1796,15 +1816,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-
+								  
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-
+				
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -1833,7 +1853,7 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object.
+ * @return the newly allocated buffer state object. 
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
@@ -1843,23 +1863,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return NULL;
+		return 0;
 
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = NULL;
+	b->yy_input_file = 0;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer( b  );
+	yy_switch_to_buffer(b  );
 
 	return b;
 }
@@ -1872,10 +1892,10 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (const char * yystr )
+YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
 {
     
-	return yy_scan_bytes( yystr, (int) strlen(yystr) );
+	return yy_scan_bytes(yystr,strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
@@ -1885,16 +1905,16 @@ YY_BUFFER_STATE yy_scan_string (const char * yystr )
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	int i;
+	yy_size_t i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = (yy_size_t) (_yybytes_len + 2);
-	buf = (char *) yyalloc( n  );
+	n = _yybytes_len + 2;
+	buf = (char *) yyalloc(n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -1903,7 +1923,7 @@ YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer( buf, n );
+	b = yy_scan_buffer(buf,n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -1919,9 +1939,9 @@ YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yynoreturn yy_fatal_error (const char* msg )
+static void yy_fatal_error (yyconst char* msg )
 {
-			fprintf( stderr, "%s\n", msg );
+			(void) fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -1949,7 +1969,7 @@ static void yynoreturn yy_fatal_error (const char* msg )
  */
 int yyget_lineno  (void)
 {
-    
+        
     return yylineno;
 }
 
@@ -1972,7 +1992,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-int yyget_leng  (void)
+yy_size_t yyget_leng  (void)
 {
         return yyleng;
 }
@@ -2028,10 +2048,10 @@ static int yy_init_globals (void)
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = NULL;
+    (yy_buffer_stack) = 0;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = NULL;
+    (yy_c_buf_p) = (char *) 0;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -2040,8 +2060,8 @@ static int yy_init_globals (void)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = NULL;
-    yyout = NULL;
+    yyin = (FILE *) 0;
+    yyout = (FILE *) 0;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2056,7 +2076,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer( YY_CURRENT_BUFFER  );
+		yy_delete_buffer(YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -2077,7 +2097,7 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, const char * s2, int n )
+static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 {
 		
 	int i;
@@ -2087,7 +2107,7 @@ static void yy_flex_strncpy (char* s1, const char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (const char * s )
+static int yy_flex_strlen (yyconst char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -2099,7 +2119,7 @@ static int yy_flex_strlen (const char * s )
 
 void *yyalloc (yy_size_t  size )
 {
-			return malloc(size);
+			return (void *) malloc( size );
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
@@ -2112,7 +2132,7 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return realloc(ptr, size);
+	return (void *) realloc( (char *) ptr, size );
 }
 
 void yyfree (void * ptr )
@@ -2123,6 +2143,7 @@ void yyfree (void * ptr )
 #define YYTABLES_NAME "yytables"
 
 #line 92 "lexer.l"
+
 
 
 /**

--- a/src/util/skiplist.h
+++ b/src/util/skiplist.h
@@ -59,7 +59,7 @@ typedef struct skiplistNode {
 typedef int (*skiplistCmpFunc)(skiplistKey p1, skiplistKey p2);
 typedef int (*skiplistValCmpFunc)(const skiplistVal p1, const skiplistVal p2);
 
-typedef void (*skiplistCloneKeyFunc)(skiplistKey *key);
+typedef skiplistKey (*skiplistCloneKeyFunc)(skiplistKey key);
 typedef void (*skiplistFreeKeyFunc)(skiplistKey key);
 
 typedef struct skiplist {

--- a/src/value.c
+++ b/src/value.c
@@ -411,12 +411,6 @@ size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *b
   return offset;
 }
 
-/* Returns 1 if argument is positive, -1 if argument is negative,
- * and 0 if argument is zero (matching the return style of the strcmp family).
- * This is necessary to construct safe integer returns when the delta between
- * two double values is < 1.0 (and would thus be rounded to 0). */
-#define COMPARE_RETVAL(a) ((a) > 0) - ((a) < 0)
-
 int SIValue_Compare(SIValue a, SIValue b) {
   // Types are identical
   if (a.type == b.type) {

--- a/src/value.c
+++ b/src/value.c
@@ -427,7 +427,20 @@ int SIValue_Compare(SIValue a, SIValue b) {
   }
 
   // Types differ
-  /* Cypher specifies the following ascending order of disjoint types:
+  double tmp_a, tmp_b;
+  if (SIValue_ToDouble(&a, &tmp_a) && SIValue_ToDouble(&b, &tmp_b)) {
+    /* Both values are numeric, and both now have double representations.
+     * TODO worry about precision and overflows. This approach will
+     * not be adequate if we have high-value longs, especially. */
+    return tmp_a - tmp_b;
+  }
+
+  /* Types differ and are not comparable, so we will fall back to satisfying
+   * ordering constraints.
+   * TODO Later, we may want to separate ordering logic from comparison logic -
+   * the below is useful for ORDER BY clauses, but could be misleading in WHERE clauses.
+   *
+   * Cypher specifies the following ascending order of disjoint types:
    * - String
    * - Number
    * - NULL

--- a/src/value.h
+++ b/src/value.h
@@ -39,6 +39,12 @@ typedef enum {
 
 #define SI_NUMERIC (T_INT32 | T_INT64 | T_UINT | T_FLOAT | T_DOUBLE)
 
+/* Returns 1 if argument is positive, -1 if argument is negative,
+ * and 0 if argument is zero (matching the return style of the strcmp family).
+ * This is necessary to construct safe integer returns when the delta between
+ * two double values is < 1.0 (and would thus be rounded to 0). */
+#define COMPARE_RETVAL(a) ((a) > 0) - ((a) < 0)
+
 typedef struct {
   union {
     int32_t intval;

--- a/tests/flow/test_imdb.py
+++ b/tests/flow/test_imdb.py
@@ -173,6 +173,27 @@ class ImdbFlowTest(FlowTestsBase):
         # assert query run time
         self._assert_run_time(actual_result, queries.actors_over_85_index_scan)
 
+    def test_index_scan_eighties_movies(self):
+        global redis_graph
+
+        # Execute this command directly, as its response does not contain the result set that
+        # 'redis_graph.query()' expects
+        redis_graph.redis_con.execute_command("GRAPH.QUERY", redis_graph.name, "CREATE INDEX ON :movie(year)")
+        execution_plan = redis_graph.execution_plan(queries.eighties_movies_index_scan.query)
+        self.assertIn('Index Scan', execution_plan)
+
+        actual_result = redis_graph.query(queries.eighties_movies_index_scan.query)
+
+        redis_graph.redis_con.execute_command("GRAPH.QUERY", redis_graph.name, "DROP INDEX ON :movie(year)")
+
+        # assert result set
+        self._assert_only_expected_results_are_in_actual_results(
+            actual_result,
+            queries.eighties_movies_index_scan)
+
+        # assert query run time
+        self._assert_run_time(actual_result, queries.eighties_movies_index_scan)
+
     def test_find_titles_starting_with_american(self):
         global redis_graph
         actual_result = redis_graph.query(queries.find_titles_starting_with_american_query.query)

--- a/tests/flow/test_imdb.py
+++ b/tests/flow/test_imdb.py
@@ -173,5 +173,17 @@ class ImdbFlowTest(FlowTestsBase):
         # assert query run time
         self._assert_run_time(actual_result, queries.actors_over_85_index_scan)
 
+    def test_find_titles_starting_with_american(self):
+        global redis_graph
+        actual_result = redis_graph.query(queries.find_titles_starting_with_american_query.query)
+
+        # assert result set
+        self._assert_only_expected_results_are_in_actual_results(
+            actual_result,
+            queries.find_titles_starting_with_american_query)
+
+        # assert query run time
+        self._assert_run_time(actual_result, queries.find_titles_starting_with_american_query)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_filter_tree.cpp
+++ b/tests/unit/test_filter_tree.cpp
@@ -32,7 +32,11 @@ class FilterTreeTest: public ::testing::Test {
 
         AST_FilterNode *root = New_AST_PredicateNode(lhs, EQ, rhs);
         FT_FilterNode *tree = BuildFiltersTree(root);
+
+        Free_AST_ArithmeticExpressionNode(lhs);
+        Free_AST_ArithmeticExpressionNode(rhs);
         Free_AST_FilterNode(root);
+
         return tree;
     }
 
@@ -41,7 +45,11 @@ class FilterTreeTest: public ::testing::Test {
         AST_ArithmeticExpressionNode *rhs = New_AST_AR_EXP_VariableOperandNode("him", "age");
         AST_FilterNode *root = New_AST_PredicateNode(lhs, GT, rhs);
         FT_FilterNode *tree = BuildFiltersTree(root);
+
+        Free_AST_ArithmeticExpressionNode(lhs);
+        Free_AST_ArithmeticExpressionNode(rhs);
         Free_AST_FilterNode(root);
+
         return tree;
     }
 
@@ -58,7 +66,13 @@ class FilterTreeTest: public ::testing::Test {
 
         AST_FilterNode *root = New_AST_ConditionNode(left, cond, right);
         FT_FilterNode *tree = BuildFiltersTree(root);
+
+        Free_AST_ArithmeticExpressionNode(left_lhs);
+        Free_AST_ArithmeticExpressionNode(left_rhs);
+        Free_AST_ArithmeticExpressionNode(right_lhs);
+        Free_AST_ArithmeticExpressionNode(right_rhs);
         Free_AST_FilterNode(root);
+
         return tree;
     }
 
@@ -86,7 +100,6 @@ class FilterTreeTest: public ::testing::Test {
         AST_ArithmeticExpressionNode *age_expression = New_AST_AR_EXP_ConstOperandNode(age);
         SIValue height = SI_DoubleVal(188);
         AST_ArithmeticExpressionNode *height_expression = New_AST_AR_EXP_ConstOperandNode(height);
-
         // Build the AST filter nodes
         AST_FilterNode *left_left_child = New_AST_PredicateNode(left_left_variable, GT, age_expression);
         AST_FilterNode *left_right_child = New_AST_PredicateNode(left_right_variable, LE, height_expression);
@@ -99,7 +112,10 @@ class FilterTreeTest: public ::testing::Test {
         AST_FilterNode *root = New_AST_ConditionNode(left, AND, right);
         FT_FilterNode *tree = BuildFiltersTree(root);
 
+        Free_AST_ArithmeticExpressionNode(age_expression);
+        Free_AST_ArithmeticExpressionNode(height_expression);
         Free_AST_FilterNode(root);
+
         return tree;
     }
 

--- a/tests/unit/test_filter_tree.cpp
+++ b/tests/unit/test_filter_tree.cpp
@@ -31,7 +31,7 @@ class FilterTreeTest: public ::testing::Test {
         AST_ArithmeticExpressionNode *rhs = New_AST_AR_EXP_ConstOperandNode(value);
 
         AST_FilterNode *root = New_AST_PredicateNode(lhs, EQ, rhs);
-        FT_FilterNode *tree = BuildFiltersTree(root);
+        FT_FilterNode *tree = BuildFiltersTree(root, NULL);
 
         Free_AST_ArithmeticExpressionNode(lhs);
         Free_AST_ArithmeticExpressionNode(rhs);
@@ -44,7 +44,7 @@ class FilterTreeTest: public ::testing::Test {
         AST_ArithmeticExpressionNode *lhs = New_AST_AR_EXP_VariableOperandNode("me", "age");
         AST_ArithmeticExpressionNode *rhs = New_AST_AR_EXP_VariableOperandNode("him", "age");
         AST_FilterNode *root = New_AST_PredicateNode(lhs, GT, rhs);
-        FT_FilterNode *tree = BuildFiltersTree(root);
+        FT_FilterNode *tree = BuildFiltersTree(root, NULL);
 
         Free_AST_ArithmeticExpressionNode(lhs);
         Free_AST_ArithmeticExpressionNode(rhs);
@@ -65,7 +65,7 @@ class FilterTreeTest: public ::testing::Test {
         AST_FilterNode *right = New_AST_PredicateNode(right_lhs, LE, right_rhs);
 
         AST_FilterNode *root = New_AST_ConditionNode(left, cond, right);
-        FT_FilterNode *tree = BuildFiltersTree(root);
+        FT_FilterNode *tree = BuildFiltersTree(root, NULL);
 
         Free_AST_ArithmeticExpressionNode(left_lhs);
         Free_AST_ArithmeticExpressionNode(left_rhs);
@@ -110,7 +110,7 @@ class FilterTreeTest: public ::testing::Test {
         AST_FilterNode *right = New_AST_ConditionNode(right_left_child, OR, right_right_child);
 
         AST_FilterNode *root = New_AST_ConditionNode(left, AND, right);
-        FT_FilterNode *tree = BuildFiltersTree(root);
+        FT_FilterNode *tree = BuildFiltersTree(root, NULL);
 
         Free_AST_ArithmeticExpressionNode(age_expression);
         Free_AST_ArithmeticExpressionNode(height_expression);

--- a/tests/unit/test_index.cpp
+++ b/tests/unit/test_index.cpp
@@ -129,6 +129,10 @@ TEST_F(IndexTest, StringIndex) {
     num_vals ++;
   }
   EXPECT_EQ(num_vals, expected_n);
+
+  Free_AST_FilterNode(root);
+  Free_AST_ArithmeticExpressionNode(lhs);
+  Free_AST_ArithmeticExpressionNode(rhs);
   SIValue_Free(&lb);
   IndexIter_Free(iter);
   Index_Free(str_idx);
@@ -172,6 +176,9 @@ TEST_F(IndexTest, NumericIndex) {
   }
   EXPECT_EQ(num_vals, expected_n);
 
+  Free_AST_FilterNode(root);
+  Free_AST_ArithmeticExpressionNode(lhs);
+  Free_AST_ArithmeticExpressionNode(rhs);
   IndexIter_Free(iter);
   Index_Free(num_idx);
 }
@@ -200,6 +207,7 @@ TEST_F(IndexTest, IteratorBounds) {
   Node *cur;
   SIValue *lb;
   int ctr = 0;
+  // TODO ensure lower bound is not still first value
   // Find the value of the 10th element in the index
   while ((node_id = IndexIter_Next(iter)) != NULL) {
     ctr ++;
@@ -237,6 +245,7 @@ TEST_F(IndexTest, IteratorBounds) {
     ub = GraphEntity_Get_Property((GraphEntity*)cur, num_key);
     if (ub->doubleval > lb->doubleval) break;
   }
+  Free_AST_ArithmeticExpressionNode(rhs);
   rhs = New_AST_AR_EXP_ConstOperandNode(*ub);
   AST_FilterNode *root_le = New_AST_PredicateNode(lhs, LE, rhs);
   FT_FilterNode *ub_filter_le = BuildFiltersTree(root_le);
@@ -259,6 +268,7 @@ TEST_F(IndexTest, IteratorBounds) {
    * Number of values should be 0. */
   IndexIter_Reset(iter);
   SIValue ub_last = SI_DoubleVal(lb->doubleval - 1);
+  Free_AST_ArithmeticExpressionNode(rhs);
   rhs = New_AST_AR_EXP_ConstOperandNode(ub_last);
   AST_FilterNode *root_lt_last = New_AST_PredicateNode(lhs, LT, rhs);
   FT_FilterNode *ub_filter_last = BuildFiltersTree(root_lt_last);
@@ -266,11 +276,18 @@ TEST_F(IndexTest, IteratorBounds) {
   cur_vals = count_iter_vals(iter);
   EXPECT_EQ(cur_vals, 0);
 
-  free(lb_filter_gt);
-  free(lb_filter_ge);
-  free(ub_filter_le);
-  free(ub_filter_lt);
-  free(ub_filter_last);
+  Free_AST_ArithmeticExpressionNode(lhs);
+  Free_AST_ArithmeticExpressionNode(rhs);
+  Free_AST_FilterNode(root_ge);
+  Free_AST_FilterNode(root_gt);
+  Free_AST_FilterNode(root_le);
+  Free_AST_FilterNode(root_lt);
+  Free_AST_FilterNode(root_lt_last);
+  FilterTree_Free(lb_filter_gt);
+  FilterTree_Free(lb_filter_ge);
+  FilterTree_Free(ub_filter_le);
+  FilterTree_Free(ub_filter_lt);
+  FilterTree_Free(ub_filter_last);
   IndexIter_Free(iter);
 }
 

--- a/tests/unit/test_skiplist.cpp
+++ b/tests/unit/test_skiplist.cpp
@@ -19,7 +19,7 @@ extern "C" {
 extern int compareNodes(GrB_Index a, GrB_Index b);
 extern int compareStrings(SIValue *a, SIValue *b);
 extern int compareNumerics(SIValue *a, SIValue *b);
-extern void cloneKey(SIValue **property);
+extern SIValue* cloneKey(SIValue *property);
 extern void freeKey(SIValue *key);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This resolves #106 for WHERE clauses (I think ORDER clauses should be handled similarly, but in a separate PR).

The most significant change seen here is that now predicate nodes in the filter tree are always arithmetic expressions, rather than being constant values or different graph entities. This lets us support functions in filters (`WHERE ID(a) < 100`, `WHERE LEFT(a.title, 3) = 'The'`), as well as making filter comparisons more robust in general (`WHERE 2000 < a.year` now works, for example).

Instead of storing pointers to comparison routines on the predicate nodes, all comparisons are currently using a slightly-improved `SIValue_Compare`. I would like to improve this function soon, and start using a separate routine for ORDER clauses, as being orderable in Cypher is different than being comparable.

In part, the change in comparison routines was necessary to support filters on IDs, as the ID function returns an SIValue integer type rather than a double (which is how our numerics are typically represented). 