### PR TITLE
Release module-scoped write lock and context-scoped lock separately

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -95,15 +95,11 @@ void _MGraph_AcquireWriteLock(RedisModuleCtx *ctx) {
 }
 
 // Release read/write lock.
-void _MGraph_ReleaseLock() {
+void _MGraph_ReleaseLock(RedisModuleCtx *ctx) {
     pthread_rwlock_unlock(&_rwlock);
-}
-
-/* Release the Redis global lock if it is held.
- * This should only have an effect if a thread-safe context lock
- * was acquired (which is only necessary when performing operations
- * that modify the keyspace). */
-void _MGraphUnlockContext(RedisModuleCtx *ctx) {
+    /* Release Redis global lock,
+     * this should only have an effect when the read/write lock
+     * was acquired for writing. */
     RedisModule_ThreadSafeContextUnlock(ctx);
 }
 
@@ -176,7 +172,6 @@ void _MGraph_Query(void *args) {
     RedisModuleCtx *ctx = RedisModule_GetThreadSafeContext(qctx->bc);
     AST_Query* ast = qctx->ast;
     const char *graph_name = RedisModule_StringPtrLen(qctx->graphName, NULL);
-    bool holds_lock = false;
 
     // Perform query validations before and after ModifyAST
     if (_AST_PerformValidations(ctx, ast) != AST_VALID) goto cleanup;
@@ -185,12 +180,8 @@ void _MGraph_Query(void *args) {
     if (_AST_PerformValidations(ctx, ast) != AST_VALID) goto cleanup;
 
     // If this is a write query, acquire write lock.
-    holds_lock = !AST_ReadOnly(ast);
-    if (holds_lock) {
-      _MGraph_AcquireWriteLock(ctx);
-    } else {
-      _MGraph_AcquireReadLock();
-    }
+    if(AST_ReadOnly(ast)) _MGraph_AcquireReadLock();
+    else _MGraph_AcquireWriteLock(ctx);
 
     // Try to get graph.
     Graph *g = Graph_Get(ctx, qctx->graphName);
@@ -200,7 +191,7 @@ void _MGraph_Query(void *args) {
             /* TODO: free graph if no entities were created. */
         } else {
             RedisModule_ReplyWithError(ctx, "key doesn't contains a graph object.");
-            _MGraph_ReleaseLock();
+            _MGraph_ReleaseLock(ctx);
             goto cleanup;
         }
     }
@@ -208,27 +199,21 @@ void _MGraph_Query(void *args) {
     if (ast->indexNode) { // index operation
         _index_operation(ctx, graph_name, g, ast->indexNode);
         // Release read lock
-        _MGraph_ReleaseLock();
+        _MGraph_ReleaseLock(ctx);
     } else {
         ExecutionPlan *plan = NewExecutionPlan(ctx, g, graph_name, ast, false);
         ResultSet* resultSet = ExecutionPlan_Execute(plan);
         ExecutionPlanFree(plan);
 
-        // Done accessing graph data, release lock.
-        _MGraph_ReleaseLock();
+        /* Send result-set back to client. */
+        ResultSet_Replay(resultSet);
 
         /* Replicate query only if it modified the keyspace. */
         if(ResultSetStat_IndicateModification(resultSet->stats))
             RedisModule_ReplicateVerbatim(ctx);
 
-        /* Release the Redis main thread if it is held. */
-        if (holds_lock) {
-            _MGraphUnlockContext(ctx);
-            holds_lock = false;
-        }
-
-        /* Send result-set back to client. */
-        ResultSet_Replay(resultSet);
+        // Done accessing graph data, release lock.
+        _MGraph_ReleaseLock(ctx);
 
         ResultSet_Free(resultSet);
     }
@@ -242,7 +227,6 @@ void _MGraph_Query(void *args) {
     
     // Clean up.
 cleanup:
-    if (holds_lock) _MGraphUnlockContext(ctx);
     RedisModule_UnblockClient(qctx->bc, NULL);
     Free_AST_Query(ast);
     free(qctx);
@@ -271,8 +255,7 @@ void _MGraph_BulkInsert(void *args) {
     // Force graph pending operations to complete.
     Graph_CommitPendingOps(g);
 
-    _MGraph_ReleaseLock();
-    _MGraphUnlockContext(ctx);
+    _MGraph_ReleaseLock(ctx);
 
     // Replay to caller.
     double t = simple_toc(context->tic);
@@ -327,8 +310,7 @@ void _MGraph_Delete(void *args) {
     }
 
 cleanup:
-    _MGraph_ReleaseLock();
-    _MGraphUnlockContext(ctx);
+    _MGraph_ReleaseLock(ctx);
     DeleteGraphContext_free(dCtx);
 
     char* strElapsed;


### PR DESCRIPTION
@swilly22 I'm pretty sure this change resolves issue #118, which was caused by the ThreadSafeContext lock getting released before `RedisModule_ReplicateVerbatim` was called.

In this fix, I separated the unlock calls so that the module lock is released first, then the context lock is released once the keyspace is synchronized. Does that separation actually benefit us, though? If not, we could just reorder the calls to release all locks after synchronizing the keyspace. 