### PR TITLE
filter node type by multiplying label matrix

### DIFF
--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -15,7 +15,7 @@ OpBase *NewNodeByLabelScanOp(RedisModuleCtx *ctx, QueryGraph *qg, Graph *g, cons
     nodeByLabelScan->_zero_matrix = NULL;
 
     /* Find out label matrix ID. */
-    LabelStore *store = LabelStore_Get(ctx, STORE_NODE, graph_name, label);    
+    LabelStore *store = LabelStore_Get(ctx, STORE_NODE, graph_name, label);
     if(store != NULL) {
         int label_id = store->id;
         nodeByLabelScan->iter = TuplesIter_new(Graph_GetLabel(g, label_id));

--- a/src/execution_plan/optimizations/optimizer.c
+++ b/src/execution_plan/optimizations/optimizer.c
@@ -17,5 +17,5 @@ void optimizePlan(RedisModuleCtx *ctx, const char *graph_name, ExecutionPlan *pl
     reduceFilters(plan);
 
     /* Remove redundant SCAN operations. */
-    reduceScans(plan);
+    // reduceScans(plan);
 }

--- a/src/graph/node.c
+++ b/src/graph/node.c
@@ -16,6 +16,7 @@ Node* Node_New(NodeID id, const char *label) {
 	Node* node = (Node*)calloc(1, sizeof(Node));
 	
 	node->id = id;
+	node->mat = NULL;
 	node->prop_count = 0;
 	node->outgoing_edges = NewVector(Edge*, 0);
 	node->incoming_edges = NewVector(Edge*, 0);

--- a/src/graph/node.h
+++ b/src/graph/node.h
@@ -23,6 +23,7 @@ typedef struct {
 		EntityProperty *properties;
 	};
 	char *label;			/* label attached to node */
+	GrB_Matrix mat;			/* Label matrix, associated with node. */
 	Vector* outgoing_edges;	/* list of incoming edges (ME)<-(SRC) */
 	Vector* incoming_edges;	/* list on outgoing edges (ME)->(DEST) */
 } Node;

--- a/tests/flow/test_mix_labels.py
+++ b/tests/flow/test_mix_labels.py
@@ -1,0 +1,110 @@
+import os
+import sys
+import unittest
+from redisgraph import Graph, Node, Edge
+
+# import redis
+from .disposableredis import DisposableRedis
+
+from base import FlowTestsBase
+
+redis_graph = None
+male = ["Roi", "Alon", "Omri"]
+female = ["Hila", "Lucy"]
+
+def redis():
+    return DisposableRedis(loadmodule=os.path.dirname(os.path.abspath(__file__)) + '/../../src/redisgraph.so')
+
+class GraphMixLabelsFlowTest(FlowTestsBase):
+    @classmethod
+    def setUpClass(cls):
+        print "GraphMixLabelsFlowTest"
+        global redis_graph
+        cls.r = redis()
+        cls.r.start()
+        redis_con = cls.r.client()
+        redis_graph = Graph("G", redis_con)
+
+        # cls.r = redis.Redis()
+        # redis_graph = Graph("G", cls.r)
+
+        cls.populate_graph()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.r.stop()
+        # pass
+
+    @classmethod
+    def populate_graph(cls):
+        redis_graph
+        
+        nodes = {}
+         # Create entities
+        
+        for m in male:
+            node = Node(label="male", properties={"name": m})
+            redis_graph.add_node(node)
+            nodes[m] = node
+        
+        for f in female:
+            node = Node(label="female", properties={"name": f})
+            redis_graph.add_node(node)
+            nodes[f] = node
+
+        for n in nodes:
+            for m in nodes:
+                if n == m: continue
+                edge = Edge(nodes[n], "knows", nodes[m])
+                redis_graph.add_edge(edge)
+
+        redis_graph.commit()
+
+    # Connect a single node to all other nodes.
+    def test_male_to_all(self):
+        query = """MATCH (m:male)-[:knows]->(t) RETURN m,t ORDER BY m.name"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(male) * (len(male + female)-1)))
+    
+    def test_male_to_male(self):
+        query = """MATCH (m:male)-[:knows]->(t:male) RETURN m,t ORDER BY m.name"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(male) * (len(male)-1)))
+    
+    def test_male_to_female(self):
+        query = """MATCH (m:male)-[:knows]->(t:female) RETURN m,t ORDER BY m.name"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(male) * len(female)))
+    
+    def test_female_to_all(self):
+        query = """MATCH (f:female)-[:knows]->(t) RETURN f,t ORDER BY f.name"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(female) * (len(male + female)-1)))
+
+    def test_female_to_male(self):
+        query = """MATCH (f:female)-[:knows]->(t:male) RETURN f,t ORDER BY f.name"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(female) * len(male)))
+    
+    def test_female_to_female(self):
+        query = """MATCH (f:female)-[:knows]->(t:female) RETURN f,t ORDER BY f.name"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(female) * (len(female)-1)))
+    
+    def test_all_to_female(self):
+        query = """MATCH (f)-[:knows]->(t:female) RETURN f,t ORDER BY f.name"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(male) * len(female)) + (len(female) * (len(female)-1)))
+
+    def test_all_to_male(self):
+        query = """MATCH (f)-[:knows]->(t:male) RETURN f,t ORDER BY f.name"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(male) * (len(male)-1)) + len(female) * len(male))
+    
+    def test_all_to_all(self):
+        query = """MATCH (f)-[:knows]->(t) RETURN f,t ORDER BY f.name"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(male+female) * (len(male+female)-1)))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/flow/test_multi_pattern.py
+++ b/tests/flow/test_multi_pattern.py
@@ -49,13 +49,11 @@ class GraphMultiPatternQueryFlowTest(FlowTestsBase):
 
     # Connect a single node to all other nodes.
     def test01_connect_node_to_rest(self):
-        global redis_graph
         query = """MATCH(r:person {name:"Roi"}), (f:person) WHERE f.name != r.name CREATE (r)-[:friend]->(f)"""
         actual_result = redis_graph.query(query)
         assert (actual_result.relationships_created == 6)
     
     def test02_verify_connect_node_to_rest(self):
-        global redis_graph
         query = """MATCH(r:person {name:"Roi"})-[]->(f) RETURN count(f)"""
         actual_result = redis_graph.query(query)
         friend_count = int(float(actual_result.result_set[1][0]))
@@ -63,13 +61,11 @@ class GraphMultiPatternQueryFlowTest(FlowTestsBase):
     
     # Connect every node to every node.
     def test_03_create_fully_connected_graph(self):
-        global redis_graph
         query = """MATCH(r:person), (f:person) CREATE (r)-[:friend]->(f)"""
         actual_result = redis_graph.query(query)
         assert (actual_result.relationships_created == 49)
     
     def test_04_verify_fully_connected_graph(self):
-        global redis_graph
         query = """MATCH(r:person)-[]->(f:person) RETURN count(r)"""
         actual_result = redis_graph.query(query)
         friend_count = int(float(actual_result.result_set[1][0]))
@@ -77,7 +73,6 @@ class GraphMultiPatternQueryFlowTest(FlowTestsBase):
     
     # Perform a cartesian product of 3 sets.
     def test_05_cartesian_product(self):
-        global redis_graph
         query = """MATCH(a), (b), (c) RETURN count(a)"""
         actual_result = redis_graph.query(query)
         friend_count = int(float(actual_result.result_set[1][0]))


### PR DESCRIPTION
When a relation e.g. `knows` describes connection between several node types (Male and Female) then we must apply a type filter, consider `MATCH (s)-[:knows]->(t:Male) return s,t`

if we don't filter male nodes then `t` would include all nodes ever connected to by the `knows` relation, where we're only interested in a subset.

This will require some statistics over a relation, so we can re-enable commented optimisation.


