### PR TITLE
Improve handling of unlabeled node bulk insertion

### DIFF
--- a/src/bulk_insert/bulk_insert.h
+++ b/src/bulk_insert/bulk_insert.h
@@ -11,6 +11,9 @@
 #include "redismodule.h"
 #include "./graph/graph.h"
 
+#define BULK_OK 1
+#define BULK_FAIL 0
+
 /*
 Bulk insert performs fast insertion of large amount of data,
 it's an alternative to Cypher's CREATE query, one should prefer using
@@ -84,7 +87,7 @@ RELATIONS               // relations section.
 */
 
 /* Parse bulk insert format and inserts new entities */
-void Bulk_Insert (
+int Bulk_Insert (
     RedisModuleCtx *ctx,        // Redis module context.
     RedisModuleString **argv,   // Arguments passed to bulk insert command.
     int argc,                   // Number of elements in argv.

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -30,9 +30,11 @@ OpBase* NewAllNodeScanOp(QueryGraph *qg, const Graph *g, Node **n) {
 OpResult AllNodeScanConsume(OpBase *opBase, QueryGraph* graph) {
     AllNodeScan *op = (AllNodeScan*)opBase;
     
+    NodeID id = DataBlockIterator_Position(op->iter);
     Node *node = (Node*)DataBlockIterator_Next(op->iter);
     if(node == NULL) return OP_DEPLETED;
 
+    node->id = id;
     *op->node = node;
 
     return OP_OK;

--- a/src/util/datablock/datablock_iterator.c
+++ b/src/util/datablock/datablock_iterator.c
@@ -49,6 +49,22 @@ void *DataBlockIterator_Next(DataBlockIterator *iter) {
     return item;
 }
 
+void DataBlockIterator_Skip(DataBlockIterator *iter, int advance) {
+    assert(iter);
+
+    // Advance the iterator by the specified value. If this causes the iterator to go
+    // past its endpoint, it will return NULL on the next call to DataBlockIterator_Next
+    iter->_current_pos += advance;
+    if (iter->_current_pos >= iter->_end_pos) return;
+
+    iter->_block_pos += advance;
+    // Seek the appropriate block if we've advanced past the current one.
+    while (iter->_block_pos >= BLOCK_CAP) {
+        iter->_block_pos -= BLOCK_CAP;
+        iter->_current_block = iter->_current_block->next;
+    }
+}
+
 void DataBlockIterator_Reset(DataBlockIterator *iter) {
     assert(iter);
     iter->_block_pos = iter->_start_pos % BLOCK_CAP;

--- a/src/util/datablock/datablock_iterator.h
+++ b/src/util/datablock/datablock_iterator.h
@@ -30,7 +30,7 @@ DataBlockIterator *DataBlockIterator_New (
     int step            // To scan entire range, set step to 1.
 );
 
-#define DataBlockIterator_Position(a) (a)->_current_pos
+#define DataBlockIterator_Position(iter) (iter)->_current_pos
 
 // Clones given iterator.
 DataBlockIterator *DataBlockIterator_Clone (
@@ -40,6 +40,9 @@ DataBlockIterator *DataBlockIterator_Clone (
 // Returns the next item, unless we've reached the end
 // in which case NULL is returned.
 void *DataBlockIterator_Next(DataBlockIterator *iter);
+
+// Jump the iterator forward by a specified number.
+void DataBlockIterator_Skip(DataBlockIterator *iter, int advance);
 
 // Reset iterator to original position.
 void DataBlockIterator_Reset(DataBlockIterator *iter);

--- a/src/util/datablock/datablock_iterator.h
+++ b/src/util/datablock/datablock_iterator.h
@@ -30,6 +30,8 @@ DataBlockIterator *DataBlockIterator_New (
     int step            // To scan entire range, set step to 1.
 );
 
+#define DataBlockIterator_Position(a) (a)->_current_pos
+
 // Clones given iterator.
 DataBlockIterator *DataBlockIterator_Clone (
     const DataBlockIterator *it  // Iterator to clone.


### PR DESCRIPTION
This PR resolves a few bugs surrounding the handling of unlabeled nodes.

The `AllStore` schema is now updated to accurately describe the properties of unlabeled nodes during bulk inserts, so that a proper result set can be formed from a query like `MATCH (a) RETURN a`.

Unlabeled nodes are not required to have attributes.

AllNodeScans can update node IDs like LabelScans.

Bulk inserts that generate errors do not enqueue multiple responses.


I think these are all useful fixes, and hopefully resolve the problems you encountered earlier, though the bulk syntax and token processing still seems quite fragile. We should discuss a deeper overhaul! 