### PR TITLE
Add test_valgrind command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ deploydocs: builddocs
 
 test:
 	$(MAKE) -C ./src test
+
+test_valgrind:
+	$(MAKE) -C ./src test_valgrind

--- a/src/Makefile
+++ b/src/Makefile
@@ -113,3 +113,7 @@ package: redisgraph.so
 test: $(MODULE) redisgraph.so
 	# unit tests
 	$(MAKE) -C ../tests test
+
+test_valgrind: $(MODULE) redisgraph.so
+	# Run unit tests under Valgrind
+	$(MAKE) -C ../tests test_valgrind

--- a/src/valgrind.supp
+++ b/src/valgrind.supp
@@ -1,0 +1,28 @@
+{
+   <registered functions>
+   Memcheck:Leak
+   ...
+   fun:AR_RegisterFuncs
+   fun:RedisModule_OnLoad
+   fun:moduleLoad
+   fun:moduleLoadFromQueue
+   fun:main
+}
+
+{
+   <server suppression: lzf_unitialized_hash_table>
+   Memcheck:Cond
+   fun:lzf_compress
+}
+
+{
+   <server suppression: lzf_unitialized_hash_table>
+   Memcheck:Value4
+   fun:lzf_compress
+}
+
+{
+   <server suppression: lzf_unitialized_hash_table>
+   Memcheck:Value8
+   fun:lzf_compress
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,5 +8,8 @@ test:
 	# Cypher Technology Compatibility Kit (TCK)
 	# $(MAKE) -C tck
 
+test_valgrind:
+	$(MAKE) -C unit test_valgrind
+
 clean:
 	find . -name '*.[oad]' -type f -delete

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -63,6 +63,13 @@ test: build
 		./$$t; \
 	done
 
+test_valgrind: build
+	for t in $(TEST_EXECUTABLES); do \
+		valgrind --leak-resolution=low --quiet \
+		--leak-check=full --show-leak-kinds=all --show-possibly-lost=no \
+		--suppressions=unittests.supp ./$$t; \
+	done
+
 clean:
 	rm -f gtest.a gtest_main.a *.o *.run
 .PHONY: clean

--- a/tests/unit/unittests.supp
+++ b/tests/unit/unittests.supp
@@ -1,0 +1,8 @@
+{
+   <Cloned SIValue strings>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:strdup
+   fun:SI_StringVal
+}


### PR DESCRIPTION
Run `make test_valgrind` to run all unit test files under Valgrind.