### PR TITLE
Memory patches and node iterator fix

### DIFF
--- a/src/bulk_insert/bulk_insert_context.c
+++ b/src/bulk_insert/bulk_insert_context.c
@@ -20,13 +20,7 @@ BulkInsertContext* BulkInsertContext_New
 
     context->bc = bc;
     context->argc = argc;
-    
-    // Retain strings arguments.
-    for(int i = 0; i < argc; i++)
-        RedisModule_RetainString(ctx, argv[i]);
-
-    context->argv = malloc(sizeof(RedisModuleString*) * argc);
-    memcpy(context->argv, argv, argc * sizeof(RedisModuleString*));
+    context->argv = argv;
 
     return context;
 }
@@ -35,8 +29,5 @@ void BulkInsertContext_Free
 (
     BulkInsertContext* ctx
 ) {
-    for(int i = 0; i < ctx->argc; i++)
-        RedisModule_Free(ctx->argv[i]);
-    free(ctx->argv);
     free(ctx);
 }

--- a/src/graph/edge.c
+++ b/src/graph/edge.c
@@ -88,6 +88,4 @@ void Edge_Free(Edge* edge) {
 
 	if(edge->alias != NULL) free(edge->alias);
 	if(edge->relationship != NULL) free(edge->relationship);
-	
-	free(edge);
 }

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -257,6 +257,8 @@ Graph *Graph_New(size_t n) {
     assert(n > 0);
     Graph *g = malloc(sizeof(Graph));
 
+    // TODO Our node iterators always cast the elements of this
+    // to Nodes, but only the GraphEntity portion can be safely accessed
     g->nodes = DataBlock_New(n, sizeof(GraphEntity));
     g->edges = DataBlock_New(n, sizeof(Edge));
     g->_edgesHashTbl = NULL;            // Init to NULL, required by uthash.
@@ -693,6 +695,18 @@ void Graph_Free(Graph *g) {
     }
     free(g->_labels);
 
+    DataBlockIterator *it = Graph_ScanNodes(g);
+    GraphEntity *node;
+    while ((node = (GraphEntity*)DataBlockIterator_Next(it)) != NULL) {
+      FreeGraphEntity(node);
+    }
+    DataBlockIterator_Free(it);
+
+    it = Graph_ScanEdges(g);
+    Edge *edge;
+    while ((edge = (Edge*)DataBlockIterator_Next(it)) != NULL) {
+      Edge_Free(edge);
+    }
     // Free node blocks.
     DataBlock_Free(g->nodes);
     // Free the edges hash table before modifying the edge blocks.

--- a/src/graph/node.h
+++ b/src/graph/node.h
@@ -22,6 +22,8 @@ typedef struct {
 		int prop_count;
 		EntityProperty *properties;
 	};
+  // TODO These elements should separated into a QueryGraph_Node type
+  // so that we can correct datablock sizing for nodes
 	char *label;			/* label attached to node */
 	char *alias;			/* alias attached to node */
 	GrB_Matrix mat;			/* Label matrix, associated with node. */

--- a/src/module.c
+++ b/src/module.c
@@ -227,8 +227,8 @@ void _MGraph_Query(void *args) {
     
     // Clean up.
 cleanup:
-    RedisModule_UnblockClient(qctx->bc, NULL);
     Free_AST_Query(ast);
+    RedisModule_UnblockClient(qctx->bc, NULL);
     free(qctx);
 }
 


### PR DESCRIPTION
Combined with the other leak PRs, this should resolve most if not all of the leaks in the bulk operation itself. Really, though, the leaks were not terribly significant - I estimate that DataBlock storage for the wiki dataset must take up a minimum of 4.15 gigabytes. =/