### PR TITLE
retain argv for safe access from threads

### DIFF
--- a/src/bulk_insert/bulk_insert_context.c
+++ b/src/bulk_insert/bulk_insert_context.c
@@ -7,6 +7,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "../rmutil/util.h"
 #include "./bulk_insert_context.h"
 
 BulkInsertContext* BulkInsertContext_New
@@ -20,7 +21,7 @@ BulkInsertContext* BulkInsertContext_New
 
     context->bc = bc;
     context->argc = argc;
-    context->argv = argv;
+    context->argv = RMUtil_RetainArgv(ctx, argv, argc);
 
     return context;
 }
@@ -29,5 +30,6 @@ void BulkInsertContext_Free
 (
     BulkInsertContext* ctx
 ) {
+    RMUtil_FreeRetainArgv(ctx->argv, ctx->argc);
     free(ctx);
 }

--- a/src/rmutil/util.c
+++ b/src/rmutil/util.c
@@ -260,6 +260,23 @@ int RMUtil_ParseArgsAfter(const char *token, RedisModuleString **argv, int argc,
         
 }
 
+RedisModuleString **RMUtil_RetainArgv(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModuleString **retainStrings = RedisModule_Alloc(sizeof(RedisModuleString*) * argc);
+
+    for(int i = 0; i < argc; i++) {
+        retainStrings[i] = argv[i];
+        RedisModule_RetainString(ctx, retainStrings[i]);
+    }
+
+    return retainStrings;
+}
+
+void RMUtil_FreeRetainArgv(RedisModuleString **argv, int argc) {
+    // Release retained argv.
+    for(int i = 0; i < argc; i++) RedisModule_Free(argv[i]);
+    RedisModule_Free(argv);
+}
+
 RedisModuleCallReply *RedisModule_CallReplyArrayElementByPath(
     RedisModuleCallReply *rep, const char *path) {
   if (rep == NULL) return NULL;

--- a/src/rmutil/util.h
+++ b/src/rmutil/util.h
@@ -50,6 +50,12 @@ This is useful for optional stuff like [LIMIT [offset] [limit]]
 */
 int RMUtil_ParseArgsAfter(const char *token, RedisModuleString **argv, int argc, const char *fmt, ...);
 
+/* Creates a thread safe clone of argv. */
+RedisModuleString **RMUtil_RetainArgv(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+
+/* Free retained argv. */
+void RMUtil_FreeRetainArgv(RedisModuleString **argv, int argc);
+
 int rmutil_vparseArgs(RedisModuleString **argv, int argc, int offset, const char *fmt, va_list ap);
 
 // A single key/value entry in a redis info map


### PR DESCRIPTION
when accessing argv from a worker thread, we must retain that string as redis main thread might free it.