### PR TITLE
Fix leaks in memory scoped to individual queries

### DIFF
--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -447,12 +447,11 @@ ExecutionPlan* NewExecutionPlan(RedisModuleCtx *ctx, Graph *g,
                 free(ref);
             }
             Vector_Free(references);
-
-            ExecutionPlanPrint(execution_plan);
         }
         Vector_Free(sub_trees);
     }
     
+    Vector_Free(ops);
     optimizePlan(ctx, graph_name, execution_plan);
 
     return execution_plan;

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -248,7 +248,7 @@ ExecutionPlan* NewExecutionPlan(RedisModuleCtx *ctx, Graph *g,
     size_t node_count;
     size_t edge_count;
     _Determine_Graph_Size(ast, &node_count, &edge_count);
-    QueryGraph *q = NewQueryGraph_WithCapacity(node_count, edge_count);
+    QueryGraph *q = QueryGraph_New(node_count, edge_count);
     execution_plan->query_graph = q;
 
     // Build the query graph in advance, as it will be used to construct the filter tree

--- a/src/execution_plan/ops/op.c
+++ b/src/execution_plan/ops/op.c
@@ -18,5 +18,6 @@ void OpBase_Free(OpBase *op) {
     // Free internal operation
     op->free(op);
     if(op->children) free(op->children);
+    if(op->modifies) Vector_Free(op->modifies);
     free(op);
 }

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -49,5 +49,4 @@ OpResult AllNodeScanReset(OpBase *op) {
 void AllNodeScanFree(OpBase *ctx) {
     AllNodeScan *op = (AllNodeScan *)ctx;    
     DataBlockIterator_Free(op->iter);
-    Vector_Free(op->op.modifies);
 }

--- a/src/execution_plan/ops/op_produce_results.c
+++ b/src/execution_plan/ops/op_produce_results.c
@@ -79,5 +79,13 @@ OpResult ProduceResultsReset(OpBase *op) {
 }
 
 /* Frees ProduceResults */
-void ProduceResultsFree(OpBase *op) {
+void ProduceResultsFree(OpBase *opBase) {
+    ProduceResults *op = (ProduceResults*)opBase;
+    AR_ExpNode *ae;
+    for(int i = 0; i < Vector_Size(op->return_elements); i++) {
+        Vector_Get(op->return_elements, i, &ae);
+        AR_EXP_Free(ae);
+    }
+    Vector_Free(op->return_elements);
 }
+

--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -211,10 +211,6 @@ QueryGraph* QueryGraph_New() {
     g->edge_count = 0;
     g->node_cap = DEFAULT_GRAPH_CAP;
     g->edge_cap = DEFAULT_GRAPH_CAP;
-    g->nodes = (Node**)malloc(sizeof(Node*) * g->node_cap);
-    g->edges = (Edge**)malloc(sizeof(Edge*) * g->edge_cap);
-    g->node_aliases = (char**)malloc(sizeof(char*) * g->node_cap);
-    g->edge_aliases = (char**)malloc(sizeof(char*) * g->edge_cap);
     return g;
 }
 
@@ -462,5 +458,7 @@ void QueryGraph_Free(QueryGraph* g) {
     /* Edges are freed internally by nodes. */
     free(g->nodes);
     free(g->edges);
+    free(g->node_aliases);
+    free(g->edge_aliases);
     free(g);
 }

--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -205,24 +205,19 @@ void _BuildQueryGraphAddEdge(RedisModuleCtx *ctx,
     QueryGraph_ConnectNodes(qg, src, dest, e, edge->ge.alias);
 }
 
-QueryGraph* QueryGraph_New() {
-    QueryGraph* g = (QueryGraph*)malloc(sizeof(QueryGraph));
+QueryGraph* QueryGraph_New(size_t node_cap, size_t edge_cap) {
+    QueryGraph* g = malloc(sizeof(QueryGraph));
     g->node_count = 0;
     g->edge_count = 0;
-    g->node_cap = DEFAULT_GRAPH_CAP;
-    g->edge_cap = DEFAULT_GRAPH_CAP;
-    return g;
-}
+    g->node_cap = node_cap;
+    g->edge_cap = edge_cap;
 
-QueryGraph* NewQueryGraph_WithCapacity(size_t node_cap, size_t edge_cap) {
-    QueryGraph *graph = QueryGraph_New();
-    graph->node_cap = node_cap;
-    graph->edge_cap = edge_cap;
-    graph->nodes = (Node**)malloc(sizeof(Node*) * node_cap);
-    graph->edges = (Edge**)malloc(sizeof(Edge*) * edge_cap);
-    graph->node_aliases = (char**)malloc(sizeof(char*) * node_cap);
-    graph->edge_aliases = (char**)malloc(sizeof(char*) * edge_cap);
-    return graph;
+    g->nodes = malloc(sizeof(Node*) * node_cap);
+    g->edges = malloc(sizeof(Edge*) * edge_cap);
+    g->node_aliases = malloc(sizeof(char*) * node_cap);
+    g->edge_aliases = malloc(sizeof(char*) * edge_cap);
+
+    return g;
 }
 
 void BuildQueryGraph(RedisModuleCtx *ctx, const Graph *g, const char *graph_name, QueryGraph *qg, Vector *entities) {    

--- a/src/graph/query_graph.h
+++ b/src/graph/query_graph.h
@@ -27,8 +27,9 @@ typedef struct {
     size_t edge_cap;
 } QueryGraph;
 
-QueryGraph* QueryGraph_New();
-QueryGraph* NewQueryGraph_WithCapacity(size_t node_cap, size_t edge_cap);
+/* Prepare a new query graph with initial allocations for
+ * the provided node and edge counts. */
+QueryGraph* QueryGraph_New(size_t node_cap, size_t edge_cap);
 
 /* Given AST's MATCH node constructs a graph
  * representing queried entities and the relationships

--- a/src/module.c
+++ b/src/module.c
@@ -228,6 +228,7 @@ void _MGraph_Query(void *args) {
     // Clean up.
 cleanup:
     Free_AST_Query(ast);
+    RedisModule_FreeThreadSafeContext(ctx);
     RedisModule_UnblockClient(qctx->bc, NULL);
     free(qctx);
 }
@@ -272,6 +273,7 @@ void _MGraph_BulkInsert(void *args) {
     // Clean up
 cleanup:
     _MGraph_ReleaseLock(ctx);
+    RedisModule_FreeThreadSafeContext(ctx);
     RedisModule_UnblockClient(context->bc, NULL);
     BulkInsertContext_Free(context);
 }
@@ -323,6 +325,7 @@ cleanup:
     asprintf(&strElapsed, "Graph removed, internal execution time: %.6f milliseconds", t);
     RedisModule_ReplyWithStringBuffer(ctx, strElapsed, strlen(strElapsed));
     free(strElapsed);
+    RedisModule_FreeThreadSafeContext(ctx);
     RedisModule_UnblockClient(bc, NULL);
 }
 

--- a/src/resultset/resultset.c
+++ b/src/resultset/resultset.c
@@ -282,7 +282,6 @@ ResultSet* NewResultSet(AST_Query* ast, RedisModuleCtx *ctx) {
     set->distinct = (ast->returnNode && ast->returnNode->distinct);
     set->recordCount = 0;    
     set->header = NewResultSetHeader(ast);
-    set->records = NewVector(ResultSetRecord*, 0);
     set->bufferLen = 2048;
     set->buffer = malloc(set->bufferLen);
     set->streaming = (set->header && !(set->ordered || set->aggregated));

--- a/tests/unit/test_algebraic_expression.cpp
+++ b/tests/unit/test_algebraic_expression.cpp
@@ -302,7 +302,7 @@ class AlgebraicExpressionTest: public ::testing::Test {
     QueryGraph *_build_query_graph(Graph *g) {
         /* Query
         * MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) */
-        QueryGraph *q = NewQueryGraph_WithCapacity(1, 1);
+        QueryGraph *q = QueryGraph_New(1, 1);
 
         // The following indicies are synced with Graph_AddRelation call order
         // within _build_graph, this is not ideal, but for now this will do.

--- a/tests/unit/test_algebraic_expression.cpp
+++ b/tests/unit/test_algebraic_expression.cpp
@@ -302,7 +302,7 @@ class AlgebraicExpressionTest: public ::testing::Test {
     QueryGraph *_build_query_graph(Graph *g) {
         /* Query
         * MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) */
-        QueryGraph *q = QueryGraph_New();
+        QueryGraph *q = NewQueryGraph_WithCapacity(1, 1);
 
         // The following indicies are synced with Graph_AddRelation call order
         // within _build_graph, this is not ideal, but for now this will do.


### PR DESCRIPTION
These are all pretty straightforward fixes to leaks I observed when comparing Valgrind results from sessions that issued single versus repeated queries.