### PR TITLE
Filter tree comparisons are always false between disjoint types

### DIFF
--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -97,6 +97,10 @@ FT_FilterNode* BuildFiltersTree(const AST_FilterNode *root, const QueryGraph *qg
 /* Applies a single filter to a single result.
  * Compares given values, tests if values maintain desired relation (op) */
 int _applyFilter(SIValue* aVal, SIValue* bVal, int op) {
+
+    /* Always return false if values are not of comparable types. */
+    if (!SIValue_ValuesAreComparable(*aVal, *bVal)) return 0;
+
     /* TODO Consider updating all logic around comparison routines */
     int rel = SIValue_Compare(*aVal, *bVal);
 

--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -99,7 +99,7 @@ FT_FilterNode* BuildFiltersTree(const AST_FilterNode *root, const QueryGraph *qg
 int _applyFilter(SIValue* aVal, SIValue* bVal, int op) {
 
     /* Always return false if values are not of comparable types. */
-    if (!SIValue_ValuesAreComparable(*aVal, *bVal)) return 0;
+    if (!SI_COMPARABLE(*aVal, *bVal)) return 0;
 
     /* TODO Consider updating all logic around comparison routines */
     int rel = SIValue_Compare(*aVal, *bVal);

--- a/src/value.c
+++ b/src/value.c
@@ -411,6 +411,10 @@ size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *b
   return offset;
 }
 
+int SIValue_ValuesAreComparable(const SIValue a, const SIValue b) {
+  return (a.type == b.type) || (a.type & SI_NUMERIC && b.type & SI_NUMERIC);
+}
+
 int SIValue_Compare(SIValue a, SIValue b) {
   // Types are identical
   if (a.type == b.type) {

--- a/src/value.c
+++ b/src/value.c
@@ -411,10 +411,6 @@ size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *b
   return offset;
 }
 
-int SIValue_ValuesAreComparable(const SIValue a, const SIValue b) {
-  return (a.type == b.type) || (a.type & SI_NUMERIC && b.type & SI_NUMERIC);
-}
-
 int SIValue_Compare(SIValue a, SIValue b) {
   // Types are identical
   if (a.type == b.type) {

--- a/src/value.h
+++ b/src/value.h
@@ -119,8 +119,12 @@ size_t SIValue_StringConcatLen(SIValue* strings, unsigned int string_count);
 /* Concats strings as a comma separated string. */
 size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *buf, size_t buf_len);
 
-/* Compares two SIValues, expecting a and b to be of the same type,
- * return value is similar to strcmp. */
+/* Returns true if a and b are of the same type or are both numeric types. */
+int SIValue_ValuesAreComparable(const SIValue a, const SIValue b);
+
+/* Compares two SIValues and returns a value similar to strcmp.
+ * If the values are not both strings or both numerics, the return value reflects
+ * Cypher's orderability constraint, where string > number > NULL. */
 int SIValue_Compare(SIValue a, SIValue b);
 
 void SIValue_Print(FILE *outstream, SIValue *v);

--- a/src/value.h
+++ b/src/value.h
@@ -39,6 +39,9 @@ typedef enum {
 
 #define SI_NUMERIC (T_INT32 | T_INT64 | T_UINT | T_FLOAT | T_DOUBLE)
 
+/* Returns true if aVal and bVal are of the same type or are both numeric types. */
+#define SI_COMPARABLE(aVal, bVal) ((aVal).type == (bVal).type || (((aVal).type & SI_NUMERIC) && (bVal).type & SI_NUMERIC))
+
 /* Returns 1 if argument is positive, -1 if argument is negative,
  * and 0 if argument is zero (matching the return style of the strcmp family).
  * This is necessary to construct safe integer returns when the delta between
@@ -118,9 +121,6 @@ size_t SIValue_StringConcatLen(SIValue* strings, unsigned int string_count);
 
 /* Concats strings as a comma separated string. */
 size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *buf, size_t buf_len);
-
-/* Returns true if a and b are of the same type or are both numeric types. */
-int SIValue_ValuesAreComparable(const SIValue a, const SIValue b);
 
 /* Compares two SIValues and returns a value similar to strcmp.
  * If the values are not both strings or both numerics, the return value reflects


### PR DESCRIPTION
There may be a more performant way to do this (the function could be replaced by a macro, and we could do some clever bit twiddling), but this has the benefit of readability!

This PR resolves a bug in the comparison of NULL values:
```
12:10 $ redis-cli GRAPH.QUERY imdb "MATCH (a:actor) WHERE a.fakealias > 1000 RETURN a LIMIT 1"
1) 1) 1) "a.name"
      2) "a.age"
   2) 1) "Graham McTavish"
      2) "57.000000"
2) 1) "Query internal execution time: 0.292120 milliseconds"
12:10 $ redis-cli GRAPH.QUERY imdb "MATCH (a:actor) WHERE a.fakealias < 1000 RETURN a LIMIT 1"
1) 1) 1) "a.name"
      2) "a.age"
2) 1) "Query internal execution time: 1.606249 milliseconds"
```