### PR TITLE
Add GraphBLAS Makefile target for static compilation only

### DIFF
--- a/deps/GraphBLAS/Makefile
+++ b/deps/GraphBLAS/Makefile
@@ -21,6 +21,9 @@ library:
 # the same as "make library"
 static: library
 
+static_only:
+	( cd build ; cmake $(CMAKE_OPTIONS) .. ; $(MAKE) graphblas_static )
+
 # installs GraphBLAS to the install location defined by cmake, usually
 # /usr/local/lib and /usr/local/include
 install:

--- a/src/Makefile
+++ b/src/Makefile
@@ -90,7 +90,7 @@ $(LIBTRIEMAP):
 .PHONY: $(LIBTRIEMAP)
 
 $(GRAPHBLAS):
-	$(MAKE) CMAKE_OPTIONS="-DCMAKE_CXX_FLAGS=-std=c++11" library -C ../deps/GraphBLAS
+	$(MAKE) CMAKE_OPTIONS="-DCMAKE_CXX_FLAGS=-std=c++11" static_only -C ../deps/GraphBLAS
 
 .PHONY: $(GRAPHBLAS)
 


### PR DESCRIPTION
I would have preferred a solution that restricted itself to our own Makefile, but could not manage to do so. ([This link](https://stackoverflow.com/questions/43858722/cmake-how-to-check-target-for-build) makes me think that such a fix would require us to bypass GraphBLAS's current Makefile, which I'd also prefer not to do.)

In any case, this change removes compilation of the dynamic library and the demo targets, which saves us a good amount of time in `make` and reduces console output.