### PR TITLE
Core rm mallocs

### DIFF
--- a/deps/GraphBLAS/CMakeLists.txt
+++ b/deps/GraphBLAS/CMakeLists.txt
@@ -60,18 +60,19 @@ include_directories ( Source/Template Source Source/Generated Include Demo/Inclu
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     # cmake 2.8 workaround: gcc needs to be told to do ANSI C11.
     # cmake 3.0 doesn't have this problem.
-    set (CMAKE_C_FLAGS  "-std=c11 -lm -fPIC")
+    set (CMAKE_C_FLAGS  "-std=c11 -lm -fPIC -DREDIS_MODULE_TARGET -DMALLOC=rm_malloc -DCALLOC=rm_calloc -DREALLOC=rm_realloc -DFREE=rm_free")
     if (CMAKE_C_COMPILER_VERSION VERSION_LESS 4.9)
         message (FATAL_ERROR "gcc version must be at least 4.9")
     endif ( )
 elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
     # options for icc: also needs -std=c11
-    set (CMAKE_C_FLAGS  "-std=c11 -fopenmp")
+    set (CMAKE_C_FLAGS  "-std=c11 -fopenmp -DREDIS_MODULE_TARGET -DMALLOC=rm_malloc -DCALLOC=rm_calloc -DREALLOC=rm_realloc -DFREE=rm_free")
     if (CMAKE_C_COMPILER_VERSION VERSION_LESS 18.0)
         message (FATAL_ERROR "icc version must be at least 18.0")
     endif ( )
 elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
     # options for clang
+    set (CMAKE_C_FLAGS  "-DREDIS_MODULE_TARGET -DMALLOC=rm_malloc -DCALLOC=rm_calloc -DREALLOC=rm_realloc -DFREE=rm_free")
     if (CMAKE_C_COMPILER_VERSION VERSION_LESS 3.3)
         message (FATAL_ERROR "clang version must be at least 3.3")
     endif ( )

--- a/deps/GraphBLAS/Source/GB.h
+++ b/deps/GraphBLAS/Source/GB.h
@@ -264,6 +264,8 @@ mexErrMsgTxt ("gotcha: " __FILE__ " line: " GB_XSTR(__LINE__)) ;
 // GraphBLAS can be compiled with -DMALLOC=mymallocfunc to redefine
 // the malloc function and other memory management functions.
 // By default, these are simply the system malloc, free, etc, routines.
+// Using Redis allocators requires that those functions be visible to GraphBLAS
+#include "../../../src/util/rmalloc.h"
 #ifndef MALLOC
 #define MALLOC malloc
 #endif

--- a/src/graph/graph_entity.c
+++ b/src/graph/graph_entity.c
@@ -7,19 +7,20 @@
 
 #include "graph_entity.h"
 #include <stdio.h>
+#include "../util/rmalloc.h"
 
 SIValue *PROPERTY_NOTFOUND = &(SIValue){.intval = 0, .type = T_NULL};
 
 /* Expecting e to be either *Node or *Edge */
 void GraphEntity_Add_Properties(GraphEntity *e, int prop_count, char **keys, SIValue *values) {
 	if(e->properties == NULL) {
-		e->properties = malloc(sizeof(EntityProperty) * prop_count);
+		e->properties = rm_malloc(sizeof(EntityProperty) * prop_count);
 	} else {
-		e->properties = realloc(e->properties, sizeof(EntityProperty) * (e->prop_count + prop_count));
+		e->properties = rm_realloc(e->properties, sizeof(EntityProperty) * (e->prop_count + prop_count));
 	}
 	
 	for(int i = 0; i < prop_count; i++) {
-		e->properties[e->prop_count + i].name = strdup(keys[i]);
+		e->properties[e->prop_count + i].name = rm_strdup(keys[i]);
 		e->properties[e->prop_count + i].value = values[i];
 	}
 
@@ -38,8 +39,8 @@ SIValue* GraphEntity_Get_Property(const GraphEntity *e, const char* key) {
 void FreeGraphEntity(GraphEntity *e) {
 	if(e->properties != NULL) {
 		for(int i = 0; i < e->prop_count; i++) {
-			free(e->properties[i].name);
+			rm_free(e->properties[i].name);
 		}
-		free(e->properties);
+		rm_free(e->properties);
   }
 }

--- a/src/util/arr.h
+++ b/src/util/arr.h
@@ -26,15 +26,16 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <assert.h>
+#include "rmalloc.h"
 
 /* Definition of malloc & friedns that can be overridden before including arr.h.
  * Alternatively you can include arr_rm_alloc.h, which wraps arr.h and sets the allcoation functions
  * to those of the RM_ family
  */
 #ifndef array_alloc_fn
-#define array_alloc_fn malloc
-#define array_realloc_fn realloc
-#define array_free_fn free
+#define array_alloc_fn rm_malloc
+#define array_realloc_fn rm_realloc
+#define array_free_fn rm_free
 #endif
 
 typedef struct {

--- a/src/util/datablock/datablock.c
+++ b/src/util/datablock/datablock.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include "datablock.h"
 #include "datablock_iterator.h"
+#include "../rmalloc.h"
 
 // Computes the number of blocks required to accommodate n items.
 #define ITEM_COUNT_TO_BLOCK_COUNT(n) \
@@ -38,14 +39,14 @@
 
 Block *_Block_New(size_t itemSize) {
     assert(itemSize > 0);
-    Block *block = calloc(1, sizeof(Block) + BLOCK_CAP * itemSize);
+    Block *block = rm_calloc(1, sizeof(Block) + BLOCK_CAP * itemSize);
     block->itemSize = itemSize;
     return block;
 }
 
 void _Block_Free(Block *block) {
     assert(block);
-    free(block);
+    rm_free(block);
 }
 
 //------------------------------------------------------------------------------
@@ -58,9 +59,9 @@ void _DataBlock_AddBlocks(DataBlock *dataBlock, size_t blockCount) {
     size_t prevBlockCount = dataBlock->blockCount;
     dataBlock->blockCount += blockCount;
     if(!dataBlock->blocks)
-        dataBlock->blocks = malloc(sizeof(Block*) * dataBlock->blockCount);
+        dataBlock->blocks = rm_malloc(sizeof(Block*) * dataBlock->blockCount);
     else
-        dataBlock->blocks = realloc(dataBlock->blocks, sizeof(Block*) * dataBlock->blockCount);
+        dataBlock->blocks = rm_realloc(dataBlock->blocks, sizeof(Block*) * dataBlock->blockCount);
 
     int i;
     for(i = prevBlockCount; i < dataBlock->blockCount; i++) {
@@ -73,7 +74,7 @@ void _DataBlock_AddBlocks(DataBlock *dataBlock, size_t blockCount) {
 }
 
 DataBlock *DataBlock_New(size_t itemCap, size_t itemSize) {
-    DataBlock *dataBlock = malloc(sizeof(DataBlock));    
+    DataBlock *dataBlock = rm_malloc(sizeof(DataBlock));
     dataBlock->itemCount = 0;
     dataBlock->itemSize = itemSize;
     dataBlock->blockCount = 0;
@@ -159,6 +160,6 @@ void DataBlock_Free(DataBlock *dataBlock) {
     for(int i = 0; i < dataBlock->blockCount; i++)
         _Block_Free(dataBlock->blocks[i]);
 
-    free(dataBlock->blocks);
-    free(dataBlock);
+    rm_free(dataBlock->blocks);
+    rm_free(dataBlock);
 }

--- a/src/util/rmalloc.c
+++ b/src/util/rmalloc.c
@@ -1,0 +1,12 @@
+#include "rmalloc.h"
+
+/* Redefine the allocator functions to use the malloc family.
+ * Only to be used when running module code from a non-Redis
+ * context, such as unit tests. */
+void Alloc_Reset() {
+  RedisModule_Alloc = malloc;
+  RedisModule_Realloc = realloc;
+  RedisModule_Calloc = calloc;
+  RedisModule_Free = free;
+  RedisModule_Strdup = strdup;
+}

--- a/src/util/rmalloc.h
+++ b/src/util/rmalloc.h
@@ -1,0 +1,55 @@
+#ifndef __REDISGRAPH_ALLOC__
+#define __REDISGRAPH_ALLOC__
+
+#include <stdlib.h>
+#include <string.h>
+#include "../redismodule.h"
+
+#ifdef REDIS_MODULE_TARGET /* Set this when compiling your code as a module */
+
+static inline void *rm_malloc(size_t n) {
+  return RedisModule_Alloc(n);
+}
+static inline void *rm_calloc(size_t nelem, size_t elemsz) {
+  return RedisModule_Calloc(nelem, elemsz);
+}
+static inline void *rm_realloc(void *p, size_t n) {
+  return RedisModule_Realloc(p, n);
+}
+static inline void rm_free(void *p) {
+  RedisModule_Free(p);
+}
+static inline char *rm_strdup(const char *s) {
+  return RedisModule_Strdup(s);
+}
+
+static char *rm_strndup(const char *s, size_t n) {
+  char *ret = rm_malloc(n + 1);
+
+  if (ret) {
+    ret[n] = '\0';
+    memcpy(ret, s, n);
+  }
+  return ret;
+}
+#endif
+#ifndef REDIS_MODULE_TARGET
+/* for non redis module targets */
+#define rm_malloc malloc
+#define rm_free free
+#define rm_calloc calloc
+#define rm_realloc realloc
+#define rm_strdup strdup
+#define rm_strndup strndup
+#endif
+
+#define rm_new(x) rm_malloc(sizeof(x))
+
+/* Revert the allocator patches so that
+ * the stdlib malloc functions will be used
+ * for use when executing code from non-Redis
+ * contexts like unit tests. */
+void Alloc_Reset(void);
+
+#endif
+

--- a/tests/unit/test_algebraic_expression.cpp
+++ b/tests/unit/test_algebraic_expression.cpp
@@ -18,6 +18,7 @@ extern "C" {
 #include "../../src/graph/query_graph.h"
 #include "../../src/util/simple_timer.h"
 #include "../../src/arithmetic/algebraic_expression.h"
+#include "../../src/util/rmalloc.h"
 
 #ifdef __cplusplus
 }
@@ -40,6 +41,8 @@ class AlgebraicExpressionTest: public ::testing::Test {
         assert(GrB_init(GrB_NONBLOCKING) == GrB_SUCCESS);
         srand(time(NULL));
 
+        // Use the malloc family for allocations
+        Alloc_Reset();
         // Create a graph
         g = _build_graph();
 

--- a/tests/unit/test_all_paths.cpp
+++ b/tests/unit/test_all_paths.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 #include "../../src/algorithms/algorithms.h"
+#include "../../src/util/rmalloc.h"
 
 #ifdef __cplusplus
 }
@@ -23,6 +24,9 @@ class AllPathsTest: public ::testing::Test {
     {
         // Initialize GraphBLAS.
         GrB_init(GrB_NONBLOCKING);
+
+        // Use the malloc family for allocations
+        Alloc_Reset();
     }
 
     static void TearDownTestCase()

--- a/tests/unit/test_arithmetic_expression.cpp
+++ b/tests/unit/test_arithmetic_expression.cpp
@@ -16,6 +16,7 @@ extern "C" {
 #include "../../src/graph/node.h"
 #include "../../src/arithmetic/agg_funcs.h"
 #include "../../src/execution_plan/record.h"
+#include "../../src/util/rmalloc.h"
 
 #ifdef __cplusplus
 }
@@ -25,6 +26,9 @@ class ArithmeticTest: public ::testing::Test {
   protected:
     Record emptyRecord = Record_Empty();
     static void SetUpTestCase() {
+      // Use the malloc family for allocations
+      Alloc_Reset();
+
       AR_RegisterFuncs();
       Agg_RegisterFuncs();
     }

--- a/tests/unit/test_datablock.cpp
+++ b/tests/unit/test_datablock.cpp
@@ -14,12 +14,18 @@ extern "C" {
 #include <stdio.h>
 #include <string.h>
 #include "../../src/util/datablock/datablock.h"
+#include "../../src/util/rmalloc.h"
 
 #ifdef __cplusplus
 }
 #endif
 
 class DataBlockTest: public ::testing::Test {
+  protected:
+    static void SetUpTestCase() {
+        // Use the malloc family for allocations
+        Alloc_Reset();
+    }
 };
 
 

--- a/tests/unit/test_graph.cpp
+++ b/tests/unit/test_graph.cpp
@@ -17,6 +17,7 @@ extern "C"
 #include "../../src/GraphBLASExt/tuples_iter.h"
 #include "../../deps/GraphBLAS/Include/GraphBLAS.h"
 #include "../../src/util/datablock/datablock_iterator.h"
+#include "../../src/util/rmalloc.h"
 
 #ifdef __cplusplus
 }
@@ -35,6 +36,9 @@ class GraphTest : public ::testing::Test
         // Initialize GraphBLAS.
         GrB_init(GrB_NONBLOCKING);
         srand(time(NULL));
+
+        // Use the malloc family for allocations
+        Alloc_Reset();
     }
 
     static void TearDownTestCase()

--- a/tests/unit/test_gxb_matrix_del.cpp
+++ b/tests/unit/test_gxb_matrix_del.cpp
@@ -11,11 +11,17 @@
 extern "C" {
 #endif
 #include "../../src/GraphBLASExt/GxB_Delete.h"
+#include "../../src/util/rmalloc.h"
 #ifdef __cplusplus
 }
 #endif
 
 class GxB_DeleteTest: public ::testing::Test {
+  protected:
+    static void SetUpTestCase() {
+        // Use the malloc family for allocations
+        Alloc_Reset();
+    }
 };
 
 TEST_F(GxB_DeleteTest, GxB_Delete) {

--- a/tests/unit/test_index.cpp
+++ b/tests/unit/test_index.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 #include "../../src/index/index.h"
+#include "../../src/util/rmalloc.h"
 extern Index* buildIndex(Graph *g, const GrB_Matrix label_matrix, const char *label, const char *prop_str);
 
 #ifdef __cplusplus
@@ -29,6 +30,9 @@ class IndexTest: public ::testing::Test {
 
     static void SetUpTestCase() {
       srand(time(NULL));
+
+      // Use the malloc family for allocations
+      Alloc_Reset();
     }
 
     void TearDown() {

--- a/tests/unit/test_skiplist.cpp
+++ b/tests/unit/test_skiplist.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include "../../src/value.h"
 #include "../../src/graph/node.h"
 #include "../../src/index/index.h"
+#include "../../src/util/rmalloc.h"
 
 // Skiplist comparator functions
 extern int compareNodes(GrB_Index a, GrB_Index b);
@@ -28,6 +29,11 @@ extern void freeKey(SIValue *key);
 
 class SkiplistTest: public ::testing::Test {
   protected:
+    static void SetUpTestCase() {
+        // Use the malloc family for allocations
+        Alloc_Reset();
+    }
+
     char *words[8] = {"foo", "bar", "zap", "pomo",
                      "pera", "arancio", "limone", NULL};
     const char *node_label = "default_label";

--- a/tests/unit/test_tuples_iter.cpp
+++ b/tests/unit/test_tuples_iter.cpp
@@ -13,6 +13,7 @@ extern "C" {
 
 #include "../../deps/GraphBLAS/Include/GraphBLAS.h"
 #include "../../src/GraphBLASExt/tuples_iter.h"
+#include "../../src/util/rmalloc.h"
 
 #ifdef __cplusplus
 }
@@ -22,6 +23,9 @@ class TuplesTest: public ::testing::Test {
   protected:
     static void SetUpTestCase() {
       GrB_init(GrB_NONBLOCKING);
+
+      // Use the malloc family for allocations
+      Alloc_Reset();
     }
 
     static void TearDownTestCase() {


### PR DESCRIPTION
This PR switches to Redis allocation handling for:
- All GraphBLAS calls
- Datablocks
- GraphEntity properties
- All `arr.h` allocations
- The `Graph` object and its members

A bit of profiling (using Massif and Redis's info commands) suggest that these changes capture the vast majority of long-term allocations in the module. Outside of `arr.h`-dependent allocations, most temporary memory (things scoped to individual queries) are not captured by these changes.

I'm not sure why, but the Redis command `MEMORY USAGE [key]` on any graph artifact reports exactly the same (very minor) usage as the master branch shows. `MEMORY STATS`, however, seems to reflect the size of the data set and the average number of bytes per key fairly accurately.
