### PR TITLE
Add deny-oom and deny-script flags to GRAPH commands

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -73,19 +73,19 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     if (_RegisterDataTypes(ctx) != REDISMODULE_OK) return REDISMODULE_ERR;
 
-    if(RedisModule_CreateCommand(ctx, "graph.QUERY", MGraph_Query, "write", 1, 1, 1) == REDISMODULE_ERR) {
+    if(RedisModule_CreateCommand(ctx, "graph.QUERY", MGraph_Query, "write deny-oom deny-script", 1, 1, 1) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
 
-    if(RedisModule_CreateCommand(ctx, "graph.DELETE", MGraph_Delete, "write", 1, 1, 1) == REDISMODULE_ERR) {
+    if(RedisModule_CreateCommand(ctx, "graph.DELETE", MGraph_Delete, "write deny-script", 1, 1, 1) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
 
-    if(RedisModule_CreateCommand(ctx, "graph.EXPLAIN", MGraph_Explain, "write", 1, 1, 1) == REDISMODULE_ERR) {
+    if(RedisModule_CreateCommand(ctx, "graph.EXPLAIN", MGraph_Explain, "write deny-script", 1, 1, 1) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
 
-    if(RedisModule_CreateCommand(ctx, "graph.BULK", MGraph_BulkInsert, "write", 1, 1, 1) == REDISMODULE_ERR) {
+    if(RedisModule_CreateCommand(ctx, "graph.BULK", MGraph_BulkInsert, "write deny-oom deny-script", 1, 1, 1) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
 


### PR DESCRIPTION
deny-oom in action looks like:
`(error) OOM command not allowed when used memory > 'maxmemory'.`

This PR adds that to QUERY and BULK, and deny-script to all commands (Lua is entirely unsupported for us because of the blocking logic).