### PR TITLE
Don't flush changes to matrices after bulk insert operations

### DIFF
--- a/src/commands/cmd_bulk_insert.c
+++ b/src/commands/cmd_bulk_insert.c
@@ -50,9 +50,6 @@ void _MGraph_BulkInsert(void *args) {
     // Exit if insertion failed
     if (rc == BULK_FAIL) goto cleanup;
 
-    // Force graph pending operations to complete.
-    Graph_CommitPendingOps(g);
-
     // Replay to caller.
     double t = simple_toc(context->tic);
     char timings[1024] = {0};


### PR DESCRIPTION
Pretty self-explanatory, but it works fine! Inserting 28 million edges, my speedup was about 7-8%, which isn't amazing, but it should continue to grow as graphs get larger.