### PR TITLE
doc update to explain how to delete a node

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -415,7 +415,7 @@ Returns: `String indicating if operation succeeded or failed.`
 GRAPH.DELETE us_government
 ```
 
-*Note*: if you'd like to delete a node from the graph (not the entire graph), you simply execute a `MATCH` query and pass the alias to the Redis `DELETE` command:
+*Note*: if you'd like to delete a node from the graph (not the entire graph), you simply execute a `MATCH` query and pass the alias to the `DELETE` clause:
 
 ```
 MATCH (x:y {propname: propvalue}) DELETE x

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -421,7 +421,7 @@ GRAPH.DELETE us_government
 MATCH (x:y {propname: propvalue}) DELETE x
 ```
 
-Beware that deleting a node, all of the node's incoming/outgoing edges will also be removed.
+Beware that when you delete a node, all of the node's incoming/outgoing edges will also be removed.
 
 ## GRAPH.EXPLAIN
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -415,6 +415,14 @@ Returns: `String indicating if operation succeeded or failed.`
 GRAPH.DELETE us_government
 ```
 
+*Note*: if you'd like to delete a node from the graph (not the entire graph), you simply execute a `MATCH` query and pass the alias to the Redis `DELETE` command:
+
+```
+MATCH (x:y {propname: propvalue}) DELETE x
+```
+
+Beware that deleting a node, all of the node's incoming/outgoing edges will also be removed.
+
 ## GRAPH.EXPLAIN
 
 Constructs a query execution plan but does not run it. Inspect this execution plan to better


### PR DESCRIPTION
Related to [this discussion about improving docs for deleting a node](https://github.com/RedisLabsModules/redis-graph/issues/158#issuecomment-433639549).

I think -- given the way the docs are structured...it seemed to me to put it under the `GRAPH.DELETE` section....primarily because that is the first place I looked at to find out how to delete a node -- then I noticed it was a whole graph delete.  So, most people are going to look there, and having a minor note like this will help folks, I think.