### PR TITLE
Build GraphBLAS with 8 jobs by default

### DIFF
--- a/deps/GraphBLAS/Makefile
+++ b/deps/GraphBLAS/Makefile
@@ -22,7 +22,7 @@ library:
 static: library
 
 static_only:
-	( cd build ; cmake $(CMAKE_OPTIONS) .. ; $(MAKE) graphblas_static )
+	( cd build ; cmake $(CMAKE_OPTIONS) .. ; $(MAKE) -j4 graphblas_static )
 
 # installs GraphBLAS to the install location defined by cmake, usually
 # /usr/local/lib and /usr/local/include


### PR DESCRIPTION
So far as I can tell, there is no good portable way to choose a good number of jobs for the `-j` flag to Makefiles. I'd still rather have it be _something_ other than 1, and 8 is my personal standard choice. This compiles GraphBLAS static in 45 seconds on my machine (against 167 seconds on the master branch).
