### PR TITLE
Don't allow entities to be referenced by multiple match patterns

### DIFF
--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -186,6 +186,34 @@ AST_Validation _Validate_MATCH_Clause(const AST_Query *ast, char **reason) {
   }
 
   TrieMap_Free(edgeAliases, TrieMap_NOP_CB);
+
+  /* Verify that no alias appears in multiple independent patterns.
+   * TODO We should introduce support for this when possible. */
+  size_t patternCount = Vector_Size(ast->matchNode->patterns);
+  if (Vector_Size(ast->matchNode->patterns) > 1) {
+    TrieMap *reused_entities = NewTrieMap();
+    Vector *pattern;
+    AST_GraphEntity *elem;
+    for (size_t i = 0; i < patternCount; i ++) {
+      Vector_Get(ast->matchNode->patterns, i, &pattern);
+      for (int j = 0; j < Vector_Size(pattern); j ++) {
+        Vector_Get(pattern, j, &elem);
+        char *alias = elem->alias;
+        if (!alias) continue;
+        void *val = TrieMap_Find(reused_entities, alias, strlen(alias));
+        // If this alias has been used in a previous pattern, emit an error.
+        if (val != TRIEMAP_NOTFOUND && (size_t)val != i) {
+          asprintf(reason, "Alias '%s' reused. Entities with the same alias may not be referenced in multiple patterns.", alias);
+          res = AST_INVALID;
+          break;
+        }
+        // Use the pattern index as a value, as it is valid to reuse a node alias within a pattern.
+        TrieMap_Add(reused_entities, alias, strlen(alias), (void *)i, TrieMap_DONT_CARE_REPLACE);
+      }
+    }
+    TrieMap_Free(reused_entities, TrieMap_NOP_CB);
+  }
+
   return res;
 }
 


### PR DESCRIPTION
This PR was intended to resolve #172 by verifying that no MATCH entities appear in multiple patterns.
(This is a temporary solution, as ultimately we should be able to allow that behavior).

 It has some additional logic to allow multiple references to entities within a pattern, because that should be fine.
However, these don't actually resolve properly right now:
```
16:54 $ redis-cli GRAPH.QUERY G "CREATE (a:l {val: 1})-[:e]->(:l {val:2})-[:e]->(a)"
1) (empty list or set)
2) 1) "Labels added: 1"
   2) "Nodes created: 2"
   3) "Properties set: 2"
   4) "Relationships created: 2"
   5) "Query internal execution time: 0.663885 milliseconds"
16:55 $ redis-cli GRAPH.QUERY G "MATCH (a)-[]->(a) RETURN a"
1) 1) 1) "a.val"
   2) 1) "2.000000"
   3) 1) "1.000000"
2) 1) "Query internal execution time: 0.547030 milliseconds"
```
This query should have returned no results. (I think it instead returned every one-hop destination, though I'm not certain.)
If we like, I can just remove the pattern index check from this PR, and that will disallow reuse of entities even within patterns. I'd like to have that functionality, though, so  it would probably be worth taking the time to dig and see what's going wrong here!